### PR TITLE
[codex] Upgrade site discovery and reading experience

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -96,7 +96,7 @@ module.exports = {
         short_name: `Vinit Kumar`,
         start_url: `/`,
         background_color: `#ffffff`,
-        theme_color: `#663399`,
+        theme_color: `#111111`,
         display: `minimal-ui`,
         icon: `src/images/favicon-32x32.png`
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,7 +59,6 @@ module.exports = {
           // `gatsby-remark-prismjs`,
           `gatsby-remark-copy-linked-files`,
           `gatsby-remark-smartypants`,
-          `gatsby-plugin-react-helmet`,
         ],
       },
     },
@@ -70,9 +69,7 @@ module.exports = {
       resolve: `gatsby-plugin-google-gtag`,
       options: {
         // You can add multiple tracking ids and a pageview event will be fired for all of them.
-        trackingIds: [
-          `G-FGECNRP32R`
-        ],
+        trackingIds: [`G-FGECNRP32R`],
         // This object gets passed directly to the gtag config command
         // This config will be shared across all trackingIds
         gtagConfig: {
@@ -98,12 +95,11 @@ module.exports = {
         background_color: `#ffffff`,
         theme_color: `#111111`,
         display: `minimal-ui`,
-        icon: `src/images/favicon-32x32.png`
+        icon: `src/images/favicon-32x32.png`,
       },
     },
     `gatsby-plugin-twitter`,
     `gatsby-plugin-offline`,
-    `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-plugin-typography`,
       options: {
@@ -128,10 +124,10 @@ module.exports = {
         feeds: [
           {
             serialize: ({ query: { site, allMarkdownRemark } }) => {
-              return allMarkdownRemark.edges.map(edge => {
-                const isTil = edge.node.fields.collection === 'til'
-                const title = isTil 
-                  ? `[TIL] ${edge.node.frontmatter.title}` 
+              return allMarkdownRemark.edges.map((edge) => {
+                const isTil = edge.node.fields.collection === "til"
+                const title = isTil
+                  ? `[TIL] ${edge.node.frontmatter.title}`
                   : edge.node.frontmatter.title
                 return Object.assign({}, edge.node.frontmatter, {
                   title,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -104,6 +104,7 @@ exports.createPages = ({ graphql, actions }) => {
         component: blogPost,
         context: {
           slug: post.node.fields.slug,
+          tags: normalizeTags(post.node.frontmatter.tags),
           previous,
           next,
         },
@@ -120,6 +121,7 @@ exports.createPages = ({ graphql, actions }) => {
         component: tilPost,
         context: {
           slug: post.node.fields.slug,
+          tags: normalizeTags(post.node.frontmatter.tags),
           previous,
           next,
         },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,18 @@
 const path = require(`path`)
 const { createFilePath } = require(`gatsby-source-filesystem`)
 
+const normalizeTag = tag =>
+  String(tag || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+
+const normalizeTags = tags => {
+  if (!tags) return []
+  const rawTags = Array.isArray(tags) ? tags : String(tags).split(/[,\s]+/)
+  return Array.from(new Set(rawTags.map(normalizeTag).filter(Boolean)))
+}
+
 exports.createSchemaCustomization = ({ actions, schema }) => {
   const { createTypes } = actions
   
@@ -35,11 +47,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
         tags: {
           type: `[String]`,
           resolve(source) {
-            const tags = source.tags
-            if (!tags) return []
-            if (Array.isArray(tags)) return tags
-            if (typeof tags === 'string') return [tags]
-            return []
+            return normalizeTags(source.tags)
           }
         }
       }
@@ -52,6 +60,7 @@ exports.createPages = ({ graphql, actions }) => {
 
   const blogPost = path.resolve(`./src/templates/blog-post.js`)
   const tilPost = path.resolve(`./src/templates/til-post.js`)
+  const topicPage = path.resolve(`./src/templates/topic-page.js`)
   
   return graphql(
     `{
@@ -64,6 +73,7 @@ exports.createPages = ({ graphql, actions }) => {
         }
         frontmatter {
           title
+          tags
         }
       }
     }
@@ -78,6 +88,11 @@ exports.createPages = ({ graphql, actions }) => {
     const posts = result.data.allMarkdownRemark.edges
     const blogPosts = posts.filter(post => post.node.fields.collection === 'blog')
     const tilPosts = posts.filter(post => post.node.fields.collection === 'til')
+    const tags = new Set()
+
+    posts.forEach(post => {
+      normalizeTags(post.node.frontmatter.tags).forEach(tag => tags.add(tag))
+    })
 
     // Create blog posts pages
     blogPosts.forEach((post, index) => {
@@ -107,6 +122,16 @@ exports.createPages = ({ graphql, actions }) => {
           slug: post.node.fields.slug,
           previous,
           next,
+        },
+      })
+    })
+
+    tags.forEach(tag => {
+      createPage({
+        path: `/topics/${tag}/`,
+        component: topicPage,
+        context: {
+          tag,
         },
       })
     })

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -11,23 +11,13 @@ const themeScript = `
 })();
 `
 
-export const onRenderBody = ({ setHeadComponents, setPreBodyComponents, setPostBodyComponents }) => {
+export const onRenderBody = ({ setHeadComponents, setPreBodyComponents }) => {
   setHeadComponents([])
   
   setPreBodyComponents([
     <script
       key="theme-script"
       dangerouslySetInnerHTML={{ __html: themeScript }}
-    />,
-  ])
-  
-  // Load the deckdeckgo highlight-code web component script
-  // This ensures code highlighting works on direct page loads (not just client-side navigation)
-  setPostBodyComponents([
-    <script
-      key="deckdeckgo-highlight-code"
-      type="module"
-      src="https://unpkg.com/@deckdeckgo/highlight-code@latest/dist/deckdeckgo-highlight-code/deckdeckgo-highlight-code.esm.js"
     />,
   ])
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "gatsby-plugin-image": "^3.16.0",
     "gatsby-plugin-manifest": "^5.16.0",
     "gatsby-plugin-offline": "^6.16.0",
-    "gatsby-plugin-react-helmet": "^6.16.0",
     "gatsby-plugin-sharp": "^5.16.0",
     "gatsby-plugin-sitemap": "^6.16.0",
     "gatsby-plugin-twitter": "^5.16.0",
@@ -35,7 +34,6 @@
     "prismjs": "^1.30.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-helmet": "^6.1.0",
     "react-typography": "^0.16.23",
     "styled-components": "^6.3.9",
     "tar-fs": "^3.1.1",
@@ -59,11 +57,11 @@
     "url": "git+https://github.com/gatsbyjs/gatsby-starter-blog.git"
   },
   "scripts": {
-    "build": "gatsby build",
-    "develop": "gatsby develop",
+    "build": "GATSBY_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"${NODE_OPTIONS:-} --require=./scripts/use-userland-punycode.js\" gatsby build",
+    "develop": "GATSBY_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"${NODE_OPTIONS:-} --require=./scripts/use-userland-punycode.js\" gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
-    "serve": "gatsby serve",
+    "serve": "GATSBY_TELEMETRY_DISABLED=1 NODE_OPTIONS=\"${NODE_OPTIONS:-} --require=./scripts/use-userland-punycode.js\" gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
     "upgrade-interactive": "npm-check --update"
   },

--- a/scripts/use-userland-punycode.js
+++ b/scripts/use-userland-punycode.js
@@ -1,0 +1,12 @@
+const Module = require("module")
+
+const userlandPunycode = require.resolve("punycode/")
+const originalLoad = Module._load
+
+Module._load = function load(request, parent, isMain) {
+  if (request === "punycode" || request === "node:punycode") {
+    return originalLoad(userlandPunycode, parent, isMain)
+  }
+
+  return originalLoad(request, parent, isMain)
+}

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -15,25 +15,21 @@ const externalLinks = [
     href: "https://vinitkumar.github.io/vinitkumar.pdf", 
     label: "Resume", 
     className: "nav-link--resume",
-    icon: "📄"
   },
   { 
     href: "https://www.linkedin.com/in/vinitatlinkedin/", 
     label: "LinkedIn", 
     className: "nav-link--linkedin",
-    icon: null
   },
   { 
     href: "https://x.com/intent/user?screen_name=vinitkme", 
     label: "Twitter", 
     className: "nav-link--twitter",
-    icon: null
   },
   { 
     href: "https://github.com/vinitkumar", 
     label: "GitHub", 
     className: "nav-link--github",
-    icon: null
   },
 ]
 
@@ -44,8 +40,6 @@ const externalLinks = [
 const Navigation = () => {
   return (
     <nav className="site-nav" aria-label="Main navigation">
-      {/* Site Pages Group */}
-      <span className="nav-group-label">Pages</span>
       {internalLinks.map(link => (
         <Link
           key={link.to}
@@ -57,11 +51,8 @@ const Navigation = () => {
         </Link>
       ))}
       
-      {/* Visual Separator */}
       <span className="nav-separator" aria-hidden="true" />
       
-      {/* External Links Group */}
-      <span className="nav-group-label">Connect</span>
       {externalLinks.map(link => (
         <a
           key={link.href}
@@ -70,12 +61,10 @@ const Navigation = () => {
           rel="noopener noreferrer"
           className={`nav-link ${link.className}`}
         >
-          {link.icon && <span className="nav-icon">{link.icon}</span>}
           {link.label}
         </a>
       ))}
       
-      {/* Theme Toggle */}
       <span className="nav-separator" aria-hidden="true" />
       <ThemeToggle compact />
     </nav>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -7,28 +7,32 @@ const internalLinks = [
   { to: "/about", label: "About", className: "nav-link--about" },
   { to: "/til", label: "TIL", className: "nav-link--til" },
   { to: "/stats", label: "Stats", className: "nav-link--stats" },
-  { to: "/recommendations", label: "Recs", className: "nav-link--recommendations" },
+  {
+    to: "/recommendations",
+    label: "Recs",
+    className: "nav-link--recommendations",
+  },
 ]
 
 const externalLinks = [
-  { 
-    href: "https://vinitkumar.github.io/vinitkumar.pdf", 
-    label: "Resume", 
+  {
+    href: "https://vinitkumar.github.io/vinitkumar.pdf",
+    label: "Resume",
     className: "nav-link--resume",
   },
-  { 
-    href: "https://www.linkedin.com/in/vinitatlinkedin/", 
-    label: "LinkedIn", 
+  {
+    href: "https://www.linkedin.com/in/vinitatlinkedin/",
+    label: "LinkedIn",
     className: "nav-link--linkedin",
   },
-  { 
-    href: "https://x.com/intent/user?screen_name=vinitkme", 
-    label: "Twitter", 
+  {
+    href: "https://x.com/intent/user?screen_name=vinitkme",
+    label: "Twitter",
     className: "nav-link--twitter",
   },
-  { 
-    href: "https://github.com/vinitkumar", 
-    label: "GitHub", 
+  {
+    href: "https://github.com/vinitkumar",
+    label: "GitHub",
     className: "nav-link--github",
   },
 ]
@@ -40,7 +44,7 @@ const externalLinks = [
 const Navigation = () => {
   return (
     <nav className="site-nav" aria-label="Main navigation">
-      {internalLinks.map(link => (
+      {internalLinks.map((link) => (
         <Link
           key={link.to}
           to={link.to}
@@ -50,10 +54,10 @@ const Navigation = () => {
           {link.label}
         </Link>
       ))}
-      
+
       <span className="nav-separator" aria-hidden="true" />
-      
-      {externalLinks.map(link => (
+
+      {externalLinks.map((link) => (
         <a
           key={link.href}
           href={link.href}
@@ -64,7 +68,7 @@ const Navigation = () => {
           {link.label}
         </a>
       ))}
-      
+
       <span className="nav-separator" aria-hidden="true" />
       <ThemeToggle compact />
     </nav>

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,6 +1,10 @@
 import React, { useState, useEffect, useRef } from "react"
 import { Link } from "gatsby"
-import { getPostDescription, getPostTitle, normalizeTags } from "../utils/content"
+import {
+  getPostDescription,
+  getPostTitle,
+  normalizeTags,
+} from "../utils/content"
 
 const Search = ({ posts }) => {
   const [query, setQuery] = useState("")
@@ -17,19 +21,21 @@ const Search = ({ posts }) => {
     }
 
     const searchQuery = query.toLowerCase()
-    const filtered = posts.filter(({ node }) => {
-      const title = getPostTitle(node).toLowerCase()
-      const description = getPostDescription(node).toLowerCase()
-      const excerpt = node.excerpt?.toLowerCase() || ""
-      const tags = normalizeTags(node.frontmatter.tags).join(" ")
-      
-      return (
-        title.includes(searchQuery) ||
-        description.includes(searchQuery) ||
-        excerpt.includes(searchQuery) ||
-        tags.includes(searchQuery)
-      )
-    }).slice(0, 8)
+    const filtered = posts
+      .filter(({ node }) => {
+        const title = getPostTitle(node).toLowerCase()
+        const description = getPostDescription(node).toLowerCase()
+        const excerpt = node.excerpt?.toLowerCase() || ""
+        const tags = normalizeTags(node.frontmatter.tags).join(" ")
+
+        return (
+          title.includes(searchQuery) ||
+          description.includes(searchQuery) ||
+          excerpt.includes(searchQuery) ||
+          tags.includes(searchQuery)
+        )
+      })
+      .slice(0, 8)
 
     setResults(filtered)
     setActiveIndex(filtered.length > 0 ? 0 : -1)
@@ -37,7 +43,10 @@ const Search = ({ posts }) => {
 
   useEffect(() => {
     const handleClickOutside = (event) => {
-      if (containerRef.current && !containerRef.current.contains(event.target)) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target)
+      ) {
         setIsOpen(false)
       }
     }
@@ -50,7 +59,9 @@ const Search = ({ posts }) => {
     }
 
     const handleShortcut = (event) => {
-      const isSearchShortcut = event.key === "/" || ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k")
+      const isSearchShortcut =
+        event.key === "/" ||
+        ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k")
       if (isSearchShortcut && document.activeElement !== inputRef.current) {
         event.preventDefault()
         inputRef.current?.focus()
@@ -61,7 +72,7 @@ const Search = ({ posts }) => {
     document.addEventListener("mousedown", handleClickOutside)
     document.addEventListener("keydown", handleEscape)
     document.addEventListener("keydown", handleShortcut)
-    
+
     return () => {
       document.removeEventListener("mousedown", handleClickOutside)
       document.removeEventListener("keydown", handleEscape)
@@ -78,17 +89,17 @@ const Search = ({ posts }) => {
     setQuery("")
   }
 
-  const handleKeyDown = event => {
+  const handleKeyDown = (event) => {
     if (!isOpen || results.length === 0) return
 
     if (event.key === "ArrowDown") {
       event.preventDefault()
-      setActiveIndex(index => (index + 1) % results.length)
+      setActiveIndex((index) => (index + 1) % results.length)
     }
 
     if (event.key === "ArrowUp") {
       event.preventDefault()
-      setActiveIndex(index => (index <= 0 ? results.length - 1 : index - 1))
+      setActiveIndex((index) => (index <= 0 ? results.length - 1 : index - 1))
     }
 
     if (event.key === "Enter" && activeIndex >= 0) {
@@ -100,7 +111,9 @@ const Search = ({ posts }) => {
   return (
     <div className="search-container" ref={containerRef}>
       <div className="search-input-wrapper">
-        <span className="search-icon" aria-hidden="true">/</span>
+        <span className="search-icon" aria-hidden="true">
+          /
+        </span>
         <input
           ref={inputRef}
           type="text"
@@ -114,7 +127,9 @@ const Search = ({ posts }) => {
           role="combobox"
           aria-expanded={isOpen && query.length >= 2}
           aria-controls="site-search-results"
-          aria-activedescendant={activeIndex >= 0 ? `search-result-${activeIndex}` : undefined}
+          aria-activedescendant={
+            activeIndex >= 0 ? `search-result-${activeIndex}` : undefined
+          }
         />
         {query && (
           <button
@@ -149,7 +164,9 @@ const Search = ({ posts }) => {
                 >
                   <div className="search-result-title">
                     {getPostTitle(node)}
-                    {node.frontmatter.featured && <span className="search-result-featured">Featured</span>}
+                    {node.frontmatter.featured && (
+                      <span className="search-result-featured">Featured</span>
+                    )}
                   </div>
                   <div className="search-result-date">
                     {node.frontmatter.date}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useRef } from "react"
 import { Link } from "gatsby"
+import { getPostDescription, getPostTitle, normalizeTags } from "../utils/content"
 
 const Search = ({ posts }) => {
   const [query, setQuery] = useState("")
   const [isOpen, setIsOpen] = useState(false)
   const [results, setResults] = useState([])
+  const [activeIndex, setActiveIndex] = useState(-1)
   const inputRef = useRef(null)
   const containerRef = useRef(null)
 
@@ -16,18 +18,21 @@ const Search = ({ posts }) => {
 
     const searchQuery = query.toLowerCase()
     const filtered = posts.filter(({ node }) => {
-      const title = node.frontmatter.title?.toLowerCase() || ""
-      const description = node.frontmatter.description?.toLowerCase() || ""
+      const title = getPostTitle(node).toLowerCase()
+      const description = getPostDescription(node).toLowerCase()
       const excerpt = node.excerpt?.toLowerCase() || ""
+      const tags = normalizeTags(node.frontmatter.tags).join(" ")
       
       return (
         title.includes(searchQuery) ||
         description.includes(searchQuery) ||
-        excerpt.includes(searchQuery)
+        excerpt.includes(searchQuery) ||
+        tags.includes(searchQuery)
       )
     }).slice(0, 8)
 
     setResults(filtered)
+    setActiveIndex(filtered.length > 0 ? 0 : -1)
   }, [query, posts])
 
   useEffect(() => {
@@ -44,12 +49,23 @@ const Search = ({ posts }) => {
       }
     }
 
+    const handleShortcut = (event) => {
+      const isSearchShortcut = event.key === "/" || ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k")
+      if (isSearchShortcut && document.activeElement !== inputRef.current) {
+        event.preventDefault()
+        inputRef.current?.focus()
+        setIsOpen(true)
+      }
+    }
+
     document.addEventListener("mousedown", handleClickOutside)
     document.addEventListener("keydown", handleEscape)
+    document.addEventListener("keydown", handleShortcut)
     
     return () => {
       document.removeEventListener("mousedown", handleClickOutside)
       document.removeEventListener("keydown", handleEscape)
+      document.removeEventListener("keydown", handleShortcut)
     }
   }, [])
 
@@ -62,10 +78,29 @@ const Search = ({ posts }) => {
     setQuery("")
   }
 
+  const handleKeyDown = event => {
+    if (!isOpen || results.length === 0) return
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setActiveIndex(index => (index + 1) % results.length)
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setActiveIndex(index => (index <= 0 ? results.length - 1 : index - 1))
+    }
+
+    if (event.key === "Enter" && activeIndex >= 0) {
+      event.preventDefault()
+      window.location.href = results[activeIndex].node.fields.slug
+    }
+  }
+
   return (
     <div className="search-container" ref={containerRef}>
       <div className="search-input-wrapper">
-        <span className="search-icon">🔍</span>
+        <span className="search-icon" aria-hidden="true">/</span>
         <input
           ref={inputRef}
           type="text"
@@ -73,8 +108,13 @@ const Search = ({ posts }) => {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={handleFocus}
+          onKeyDown={handleKeyDown}
           className="search-input"
           aria-label="Search posts"
+          role="combobox"
+          aria-expanded={isOpen && query.length >= 2}
+          aria-controls="site-search-results"
+          aria-activedescendant={activeIndex >= 0 ? `search-result-${activeIndex}` : undefined}
         />
         {query && (
           <button
@@ -91,28 +131,32 @@ const Search = ({ posts }) => {
       </div>
 
       {isOpen && query.length >= 2 && (
-        <div className="search-results">
+        <div className="search-results" id="site-search-results" role="listbox">
           {results.length > 0 ? (
             <>
               <div className="search-results-header">
                 {results.length} result{results.length !== 1 ? "s" : ""} found
               </div>
-              {results.map(({ node }) => (
+              {results.map(({ node }, index) => (
                 <Link
                   key={node.fields.slug}
+                  id={`search-result-${index}`}
                   to={node.fields.slug}
-                  className="search-result-item"
+                  className={`search-result-item ${index === activeIndex ? "active" : ""}`}
                   onClick={handleResultClick}
+                  role="option"
+                  aria-selected={index === activeIndex}
                 >
                   <div className="search-result-title">
-                    {node.frontmatter.title}
-                    {node.frontmatter.featured && (
-                      <span className="search-result-featured">⭐</span>
-                    )}
+                    {getPostTitle(node)}
+                    {node.frontmatter.featured && <span className="search-result-featured">Featured</span>}
                   </div>
                   <div className="search-result-date">
                     {node.frontmatter.date}
                   </div>
+                  <p className="search-result-description">
+                    {getPostDescription(node)}
+                  </p>
                 </Link>
               ))}
             </>

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -21,27 +21,29 @@ function Seo({
   title,
   type = `website`,
 }) {
-  const data = useStaticQuery(graphql`{
-  avatar: file(absolutePath: {regex: "/blog.jpg/"}) {
-    childImageSharp {
-      gatsbyImageData(width: 600, height: 400, layout: FIXED)
+  const data = useStaticQuery(graphql`
+    {
+      avatar: file(absolutePath: { regex: "/blog.jpg/" }) {
+        childImageSharp {
+          gatsbyImageData(width: 600, height: 400, layout: FIXED)
+        }
+      }
+      site {
+        siteMetadata {
+          title
+          description
+          author
+          siteUrl
+        }
+      }
     }
-  }
-  site {
-    siteMetadata {
-      title
-      description
-      author
-      siteUrl
-    }
-  }
-}`
-  )
+  `)
 
   const site = data.site.siteMetadata
   const metaDescription = description || site.description
   const canonical = `${site.siteUrl}${pathname}`
-  const imageUrl = image || `${site.siteUrl}${data.avatar.childImageSharp.gatsbyImageData.src}`
+  const imageUrl =
+    image || `${site.siteUrl}${data.avatar.childImageSharp.gatsbyImageData.src}`
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": type === "article" ? "BlogPosting" : "WebSite",
@@ -120,9 +122,8 @@ function Seo({
     >
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
     </Helmet>
-  );
+  )
 }
-
 
 Seo.propTypes = {
   date: PropTypes.string,

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -10,7 +10,17 @@ import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function Seo({ description = ``, lang = `en` , meta = [], title }) {
+function Seo({
+  date,
+  description = ``,
+  image,
+  lang = `en`,
+  meta = [],
+  pathname = `/`,
+  tags = [],
+  title,
+  type = `website`,
+}) {
   const data = useStaticQuery(graphql`{
   avatar: file(absolutePath: {regex: "/blog.jpg/"}) {
     childImageSharp {
@@ -28,14 +38,43 @@ function Seo({ description = ``, lang = `en` , meta = [], title }) {
 }`
   )
 
-  const metaDescription = description || data.site.siteMetadata.description
+  const site = data.site.siteMetadata
+  const metaDescription = description || site.description
+  const canonical = `${site.siteUrl}${pathname}`
+  const imageUrl = image || `${site.siteUrl}${data.avatar.childImageSharp.gatsbyImageData.src}`
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": type === "article" ? "BlogPosting" : "WebSite",
+    headline: title,
+    description: metaDescription,
+    url: canonical,
+    image: imageUrl,
+    author: {
+      "@type": "Person",
+      name: site.author,
+      url: site.siteUrl,
+    },
+    publisher: {
+      "@type": "Person",
+      name: site.author,
+    },
+    ...(date ? { datePublished: date, dateModified: date } : {}),
+    ...(tags.length > 0 ? { keywords: tags.join(", ") } : {}),
+  }
+
   return (
     <Helmet
       htmlAttributes={{
         lang,
       }}
       title={title}
-      titleTemplate={`%s | ${data.site.siteMetadata.title}`}
+      titleTemplate={`%s | ${site.title}`}
+      link={[
+        {
+          rel: `canonical`,
+          href: canonical,
+        },
+      ]}
       meta={[
         {
           name: `description`,
@@ -51,11 +90,15 @@ function Seo({ description = ``, lang = `en` , meta = [], title }) {
         },
         {
           property: `og:type`,
-          content: `website`,
+          content: type,
+        },
+        {
+          property: `og:url`,
+          content: canonical,
         },
         {
           property: `og:image`,
-          content: `${data.site.siteMetadata.siteUrl}${data.avatar.childImageSharp.gatsbyImageData.src}`,
+          content: imageUrl,
         },
         {
           name: `twitter:card`,
@@ -63,7 +106,7 @@ function Seo({ description = ``, lang = `en` , meta = [], title }) {
         },
         {
           name: `twitter:creator`,
-          content: data.site.siteMetadata.author,
+          content: site.author,
         },
         {
           name: `twitter:title`,
@@ -74,16 +117,23 @@ function Seo({ description = ``, lang = `en` , meta = [], title }) {
           content: metaDescription,
         },
       ].concat(meta)}
-    />
+    >
+      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+    </Helmet>
   );
 }
 
 
 Seo.propTypes = {
+  date: PropTypes.string,
   description: PropTypes.string,
+  image: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
+  pathname: PropTypes.string,
+  tags: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
+  type: PropTypes.string,
 }
 
 export default Seo

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -7,7 +7,6 @@
 
 import React from "react"
 import PropTypes from "prop-types"
-import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 function Seo({
@@ -64,64 +63,60 @@ function Seo({
     ...(tags.length > 0 ? { keywords: tags.join(", ") } : {}),
   }
 
+  const metaTags = [
+    {
+      name: `description`,
+      content: metaDescription,
+    },
+    {
+      property: `og:title`,
+      content: title,
+    },
+    {
+      property: `og:description`,
+      content: metaDescription,
+    },
+    {
+      property: `og:type`,
+      content: type,
+    },
+    {
+      property: `og:url`,
+      content: canonical,
+    },
+    {
+      property: `og:image`,
+      content: imageUrl,
+    },
+    {
+      name: `twitter:card`,
+      content: `summary_large_image`,
+    },
+    {
+      name: `twitter:creator`,
+      content: site.author,
+    },
+    {
+      name: `twitter:title`,
+      content: title,
+    },
+    {
+      name: `twitter:description`,
+      content: metaDescription,
+    },
+  ].concat(meta)
+
   return (
-    <Helmet
-      htmlAttributes={{
-        lang,
-      }}
-      title={title}
-      titleTemplate={`%s | ${site.title}`}
-      link={[
-        {
-          rel: `canonical`,
-          href: canonical,
-        },
-      ]}
-      meta={[
-        {
-          name: `description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:title`,
-          content: title,
-        },
-        {
-          property: `og:description`,
-          content: metaDescription,
-        },
-        {
-          property: `og:type`,
-          content: type,
-        },
-        {
-          property: `og:url`,
-          content: canonical,
-        },
-        {
-          property: `og:image`,
-          content: imageUrl,
-        },
-        {
-          name: `twitter:card`,
-          content: `summary_large_image`,
-        },
-        {
-          name: `twitter:creator`,
-          content: site.author,
-        },
-        {
-          name: `twitter:title`,
-          content: title,
-        },
-        {
-          name: `twitter:description`,
-          content: metaDescription,
-        },
-      ].concat(meta)}
-    >
+    <>
+      <html lang={lang} />
+      <title>{`${title} | ${site.title}`}</title>
+      <link rel="canonical" href={canonical} />
+      {metaTags.map((entry) => {
+        const key = entry.name || entry.property
+        return <meta key={key} {...entry} />
+      })}
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
-    </Helmet>
+    </>
   )
 }
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -9,7 +9,6 @@ const NotFoundPage = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo title="404: Not Found" />
       <h1>Not Found</h1>
       <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
     </Layout>
@@ -17,6 +16,10 @@ const NotFoundPage = ({ data, location }) => {
 }
 
 export default NotFoundPage
+
+export const Head = ({ location }) => (
+  <Seo title="404: Not Found" pathname={location.pathname} />
+)
 
 export const pageQuery = graphql`
   query {

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -46,7 +46,6 @@ const AboutIndex = (props) => {
 
   return (
     <Layout location={props.location} title={title}>
-      <Seo title="About"></Seo>
       <h1>About</h1>
       <img
         alt={author}
@@ -136,3 +135,11 @@ const AboutIndex = (props) => {
 }
 
 export default AboutIndex
+
+export const Head = ({ location }) => (
+  <Seo
+    title="About"
+    description="About Vinit Kumar, Principal Engineer and Django CMS Fellow."
+    pathname={location.pathname}
+  />
+)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,7 +18,7 @@ const POSTS_PER_PAGE = 5
 const BlogIndex = ({ data, location }) => {
   const [showFeaturedOnly, setShowFeaturedOnly] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
-  
+
   const siteTitle = data.site.siteMetadata.title
   const allPosts = data.allMarkdownRemark.edges
   const tilPosts = data.allTil.edges
@@ -28,7 +28,7 @@ const BlogIndex = ({ data, location }) => {
       const urlParams = new URLSearchParams(window.location.search)
       const featuredFilter = urlParams.get("featured")
       const pageParam = urlParams.get("page")
-      
+
       if (featuredFilter === "true") {
         setShowFeaturedOnly(true)
       }
@@ -77,7 +77,10 @@ const BlogIndex = ({ data, location }) => {
 
   const totalPages = Math.ceil(filteredPosts.length / POSTS_PER_PAGE)
   const startIndex = (currentPage - 1) * POSTS_PER_PAGE
-  const paginatedPosts = filteredPosts.slice(startIndex, startIndex + POSTS_PER_PAGE)
+  const paginatedPosts = filteredPosts.slice(
+    startIndex,
+    startIndex + POSTS_PER_PAGE
+  )
 
   const featuredCount = allPosts.filter(
     ({ node }) => node.frontmatter.featured
@@ -87,7 +90,7 @@ const BlogIndex = ({ data, location }) => {
     .slice(0, 4)
   const latestPosts = allPosts.slice(0, 5)
   const topicCounts = allPosts.reduce((counts, { node }) => {
-    normalizeTags(node.frontmatter.tags).forEach(tag => {
+    normalizeTags(node.frontmatter.tags).forEach((tag) => {
       counts[tag] = (counts[tag] || 0) + 1
     })
     return counts
@@ -110,15 +113,25 @@ const BlogIndex = ({ data, location }) => {
 
       <section className="home-hero">
         <p className="eyebrow">Principal Engineer · Django CMS Fellow</p>
-        <h1>Writing about robust systems, open source, tools, AI workflows, and engineering craft.</h1>
+        <h1>
+          Writing about robust systems, open source, tools, AI workflows, and
+          engineering craft.
+        </h1>
         <p>
-          I use this site as a working notebook: long-form essays, sharp technical notes,
-          career reflections, and project write-ups from building production software.
+          I use this site as a working notebook: long-form essays, sharp
+          technical notes, career reflections, and project write-ups from
+          building production software.
         </p>
         <div className="home-hero-actions">
-          <a href="/rss.xml" className="text-action">RSS</a>
-          <Link to="/about" className="text-action">About</Link>
-          <Link to="/recommendations" className="text-action">Recommendations</Link>
+          <a href="/rss.xml" className="text-action">
+            RSS
+          </a>
+          <Link to="/about" className="text-action">
+            About
+          </Link>
+          <Link to="/recommendations" className="text-action">
+            Recommendations
+          </Link>
         </div>
       </section>
 
@@ -144,7 +157,11 @@ const BlogIndex = ({ data, location }) => {
           </div>
           <div className="featured-post-grid">
             {featuredPosts.map(({ node }) => (
-              <Link key={node.fields.slug} to={node.fields.slug} className="featured-post-card">
+              <Link
+                key={node.fields.slug}
+                to={node.fields.slug}
+                className="featured-post-card"
+              >
                 <span>{node.frontmatter.date}</span>
                 <h3>{getPostTitle(node)}</h3>
                 <p>{getPostDescription(node)}</p>
@@ -164,7 +181,11 @@ const BlogIndex = ({ data, location }) => {
           </div>
           <div className="compact-post-list">
             {latestPosts.map(({ node }) => (
-              <Link key={node.fields.slug} to={node.fields.slug} className="compact-post-link">
+              <Link
+                key={node.fields.slug}
+                to={node.fields.slug}
+                className="compact-post-link"
+              >
                 <span>{node.frontmatter.date}</span>
                 <strong>{getPostTitle(node)}</strong>
               </Link>
@@ -182,7 +203,8 @@ const BlogIndex = ({ data, location }) => {
           <div className="topic-cloud">
             {topTopics.map(([tag, count]) => (
               <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
-                {tag}<span>{count}</span>
+                {tag}
+                <span>{count}</span>
               </Link>
             ))}
           </div>
@@ -196,11 +218,17 @@ const BlogIndex = ({ data, location }) => {
               <p className="eyebrow">Today I Learned</p>
               <h2>Short Technical Notes</h2>
             </div>
-            <Link to="/til" className="text-action">All TIL</Link>
+            <Link to="/til" className="text-action">
+              All TIL
+            </Link>
           </div>
           <div className="compact-post-list">
             {tilPosts.map(({ node }) => (
-              <Link key={node.fields.slug} to={node.fields.slug} className="compact-post-link">
+              <Link
+                key={node.fields.slug}
+                to={node.fields.slug}
+                className="compact-post-link"
+              >
                 <span>{node.frontmatter.date}</span>
                 <strong>{getPostTitle(node)}</strong>
               </Link>
@@ -210,88 +238,92 @@ const BlogIndex = ({ data, location }) => {
       )}
 
       <section className="home-section">
-      <div className="filter-controls">
-        <div>
-          <h3
-            style={{
-              margin: 0,
-              fontSize: "1.5rem",
-              color: "var(--text)",
-              marginBottom: "0.25rem",
-            }}
+        <div className="filter-controls">
+          <div>
+            <h3
+              style={{
+                margin: 0,
+                fontSize: "1.5rem",
+                color: "var(--text)",
+                marginBottom: "0.25rem",
+              }}
+            >
+              {showFeaturedOnly ? (
+                <>Featured Posts ({featuredCount})</>
+              ) : (
+                <>All Posts ({allPosts.length})</>
+              )}
+            </h3>
+            <p
+              style={{
+                margin: 0,
+                fontSize: "1.1rem",
+                color: "var(--text-muted)",
+              }}
+            >
+              {showFeaturedOnly
+                ? "Showing my most valuable and impactful writing"
+                : `Showing ${startIndex + 1}–${Math.min(startIndex + POSTS_PER_PAGE, filteredPosts.length)} of ${filteredPosts.length} posts • ${featuredCount} featured`}
+            </p>
+          </div>
+
+          <button
+            onClick={toggleFeaturedFilter}
+            className={`filter-btn ${showFeaturedOnly ? "filter-btn--active" : ""}`}
           >
-            {showFeaturedOnly ? (
-              <>Featured Posts ({featuredCount})</>
-            ) : (
-              <>All Posts ({allPosts.length})</>
-            )}
-          </h3>
-          <p
+            {showFeaturedOnly ? <>Show All Posts</> : <>Show Featured Only</>}
+          </button>
+        </div>
+
+        <div className="blog-posts-list">
+          {paginatedPosts.map(({ node }) => {
+            const title = node.frontmatter.title || node.fields.slug
+            const excerpt = node.frontmatter.description || node.excerpt
+            return (
+              <Link
+                key={node.fields.slug}
+                to={node.fields.slug}
+                className="blog-post-row"
+              >
+                <div className="blog-post-row-header">
+                  <div className="blog-post-row-meta">
+                    {node.frontmatter.featured && (
+                      <span className="blog-post-row-featured" title="Featured">
+                        ⭐
+                      </span>
+                    )}
+                    <h2 className="blog-post-row-title">{title}</h2>
+                  </div>
+                  <span className="blog-post-row-arrow">→</span>
+                </div>
+                <span className="blog-post-row-date">
+                  {node.frontmatter.date}
+                </span>
+                <p className="blog-post-row-excerpt">{excerpt}</p>
+              </Link>
+            )
+          })}
+        </div>
+
+        {/* Pagination */}
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
+
+        {/* No posts message for featured filter */}
+        {showFeaturedOnly && paginatedPosts.length === 0 && (
+          <div
             style={{
-              margin: 0,
-              fontSize: "1.1rem",
+              textAlign: "center",
+              padding: "3rem",
               color: "var(--text-muted)",
             }}
           >
-            {showFeaturedOnly
-              ? "Showing my most valuable and impactful writing"
-              : `Showing ${startIndex + 1}–${Math.min(startIndex + POSTS_PER_PAGE, filteredPosts.length)} of ${filteredPosts.length} posts • ${featuredCount} featured`}
-          </p>
-        </div>
-
-        <button
-          onClick={toggleFeaturedFilter}
-          className={`filter-btn ${showFeaturedOnly ? "filter-btn--active" : ""}`}
-        >
-          {showFeaturedOnly ? <>Show All Posts</> : <>Show Featured Only</>}
-        </button>
-      </div>
-
-      <div className="blog-posts-list">
-        {paginatedPosts.map(({ node }) => {
-          const title = node.frontmatter.title || node.fields.slug
-          const excerpt = node.frontmatter.description || node.excerpt
-          return (
-            <Link
-              key={node.fields.slug}
-              to={node.fields.slug}
-              className="blog-post-row"
-            >
-              <div className="blog-post-row-header">
-                <div className="blog-post-row-meta">
-                  {node.frontmatter.featured && (
-                    <span className="blog-post-row-featured" title="Featured">⭐</span>
-                  )}
-                  <h2 className="blog-post-row-title">{title}</h2>
-                </div>
-                <span className="blog-post-row-arrow">→</span>
-              </div>
-              <span className="blog-post-row-date">{node.frontmatter.date}</span>
-              <p className="blog-post-row-excerpt">{excerpt}</p>
-            </Link>
-          )
-        })}
-      </div>
-
-      {/* Pagination */}
-      <Pagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        onPageChange={handlePageChange}
-      />
-
-      {/* No posts message for featured filter */}
-      {showFeaturedOnly && paginatedPosts.length === 0 && (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "3rem",
-            color: "var(--text-muted)",
-          }}
-        >
-          <p style={{ fontSize: "1.1rem" }}>No featured posts found.</p>
-        </div>
-      )}
+            <p style={{ fontSize: "1.1rem" }}>No featured posts found.</p>
+          </div>
+        )}
       </section>
     </HomeLayout>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { Link, graphql } from "gatsby"
 import { Helmet } from "react-helmet"
-import { defineCustomElements as deckDeckGoHighlightElement } from "@deckdeckgo/highlight-code/dist/loader"
 
 import HomeLayout from "../components/homelayout"
 import Seo from "../components/seo"
@@ -15,10 +14,6 @@ import {
 } from "../utils/content"
 
 const POSTS_PER_PAGE = 5
-
-if (typeof window !== "undefined") {
-  deckDeckGoHighlightElement()
-}
 
 const BlogIndex = ({ data, location }) => {
   const [showFeaturedOnly, setShowFeaturedOnly] = useState(false)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,6 +7,12 @@ import HomeLayout from "../components/homelayout"
 import Seo from "../components/seo"
 import Search from "../components/Search"
 import Pagination from "../components/Pagination"
+import {
+  getPostDescription,
+  getPostTitle,
+  getTopicSlug,
+  normalizeTags,
+} from "../utils/content"
 
 const POSTS_PER_PAGE = 5
 
@@ -20,6 +26,7 @@ const BlogIndex = ({ data, location }) => {
   
   const siteTitle = data.site.siteMetadata.title
   const allPosts = data.allMarkdownRemark.edges
+  const tilPosts = data.allTil.edges
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -80,6 +87,19 @@ const BlogIndex = ({ data, location }) => {
   const featuredCount = allPosts.filter(
     ({ node }) => node.frontmatter.featured
   ).length
+  const featuredPosts = allPosts
+    .filter(({ node }) => node.frontmatter.featured)
+    .slice(0, 4)
+  const latestPosts = allPosts.slice(0, 5)
+  const topicCounts = allPosts.reduce((counts, { node }) => {
+    normalizeTags(node.frontmatter.tags).forEach(tag => {
+      counts[tag] = (counts[tag] || 0) + 1
+    })
+    return counts
+  }, {})
+  const topTopics = Object.entries(topicCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
 
   return (
     <HomeLayout location={location} title={siteTitle}>
@@ -93,10 +113,108 @@ const BlogIndex = ({ data, location }) => {
       </Helmet>
       <Seo title="Home" />
 
-      {/* Search */}
+      <section className="home-hero">
+        <p className="eyebrow">Principal Engineer · Django CMS Fellow</p>
+        <h1>Writing about robust systems, open source, tools, AI workflows, and engineering craft.</h1>
+        <p>
+          I use this site as a working notebook: long-form essays, sharp technical notes,
+          career reflections, and project write-ups from building production software.
+        </p>
+        <div className="home-hero-actions">
+          <a href="/rss.xml" className="text-action">RSS</a>
+          <Link to="/about" className="text-action">About</Link>
+          <Link to="/recommendations" className="text-action">Recommendations</Link>
+        </div>
+      </section>
+
       <Search posts={allPosts} />
 
-      {/* Filter Controls */}
+      {featuredPosts.length > 0 && (
+        <section className="home-section">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Start Here</p>
+              <h2>Featured Writing</h2>
+            </div>
+            <button
+              onClick={() => {
+                setShowFeaturedOnly(true)
+                setCurrentPage(1)
+                updateURL(true, 1)
+              }}
+              className="text-button"
+            >
+              View all featured
+            </button>
+          </div>
+          <div className="featured-post-grid">
+            {featuredPosts.map(({ node }) => (
+              <Link key={node.fields.slug} to={node.fields.slug} className="featured-post-card">
+                <span>{node.frontmatter.date}</span>
+                <h3>{getPostTitle(node)}</h3>
+                <p>{getPostDescription(node)}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="home-section home-split">
+        <div>
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Recent</p>
+              <h2>Latest Posts</h2>
+            </div>
+          </div>
+          <div className="compact-post-list">
+            {latestPosts.map(({ node }) => (
+              <Link key={node.fields.slug} to={node.fields.slug} className="compact-post-link">
+                <span>{node.frontmatter.date}</span>
+                <strong>{getPostTitle(node)}</strong>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Explore</p>
+              <h2>Topics</h2>
+            </div>
+          </div>
+          <div className="topic-cloud">
+            {topTopics.map(([tag, count]) => (
+              <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
+                {tag}<span>{count}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {tilPosts.length > 0 && (
+        <section className="home-section til-strip">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Today I Learned</p>
+              <h2>Short Technical Notes</h2>
+            </div>
+            <Link to="/til" className="text-action">All TIL</Link>
+          </div>
+          <div className="compact-post-list">
+            {tilPosts.map(({ node }) => (
+              <Link key={node.fields.slug} to={node.fields.slug} className="compact-post-link">
+                <span>{node.frontmatter.date}</span>
+                <strong>{getPostTitle(node)}</strong>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="home-section">
       <div className="filter-controls">
         <div>
           <h3
@@ -108,9 +226,9 @@ const BlogIndex = ({ data, location }) => {
             }}
           >
             {showFeaturedOnly ? (
-              <>⭐ Featured Posts ({featuredCount})</>
+              <>Featured Posts ({featuredCount})</>
             ) : (
-              <>📝 All Posts ({allPosts.length})</>
+              <>All Posts ({allPosts.length})</>
             )}
           </h3>
           <p
@@ -130,7 +248,7 @@ const BlogIndex = ({ data, location }) => {
           onClick={toggleFeaturedFilter}
           className={`filter-btn ${showFeaturedOnly ? "filter-btn--active" : ""}`}
         >
-          {showFeaturedOnly ? <>📚 Show All Posts</> : <>⭐ Show Featured Only</>}
+          {showFeaturedOnly ? <>Show All Posts</> : <>Show Featured Only</>}
         </button>
       </div>
 
@@ -179,6 +297,7 @@ const BlogIndex = ({ data, location }) => {
           <p style={{ fontSize: "1.1rem" }}>No featured posts found.</p>
         </div>
       )}
+      </section>
     </HomeLayout>
   )
 }
@@ -207,6 +326,25 @@ export const pageQuery = graphql`
             title
             description
             featured
+            tags
+          }
+        }
+      }
+    }
+    allTil: allMarkdownRemark(
+      sort: { frontmatter: { date: DESC } }
+      filter: { fields: { collection: { eq: "til" } } }
+      limit: 3
+    ) {
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            date(formatString: "MMMM DD, YYYY")
+            title
+            description
           }
         }
       }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react"
 import { Link, graphql } from "gatsby"
-import { Helmet } from "react-helmet"
 
 import HomeLayout from "../components/homelayout"
 import Seo from "../components/seo"
@@ -101,16 +100,6 @@ const BlogIndex = ({ data, location }) => {
 
   return (
     <HomeLayout location={location} title={siteTitle}>
-      <Helmet>
-        <meta
-          name="google-site-verification"
-          content="aAxhI-I1HmxoEa86D9zHsMBtY7sfAVgyX_HfqMSSCCI"
-        />
-        <meta name="msvalidate.01" content="9BD6B4DCA2B9F88A132B7DDCA1578919" />
-        <meta name="fediverse:creator" content="@vinitkme@fosstodon.org" />
-      </Helmet>
-      <Seo title="Home" />
-
       <section className="home-hero">
         <p className="eyebrow">Principal Engineer · Django CMS Fellow</p>
         <h1>
@@ -330,6 +319,27 @@ const BlogIndex = ({ data, location }) => {
 }
 
 export default BlogIndex
+
+export const Head = ({ location }) => (
+  <Seo
+    title="Home"
+    pathname={location.pathname}
+    meta={[
+      {
+        name: "google-site-verification",
+        content: "aAxhI-I1HmxoEa86D9zHsMBtY7sfAVgyX_HfqMSSCCI",
+      },
+      {
+        name: "msvalidate.01",
+        content: "9BD6B4DCA2B9F88A132B7DDCA1578919",
+      },
+      {
+        name: "fediverse:creator",
+        content: "@vinitkme@fosstodon.org",
+      },
+    ]}
+  />
+)
 
 export const pageQuery = graphql`
   {

--- a/src/pages/recommendations.js
+++ b/src/pages/recommendations.js
@@ -6,295 +6,337 @@ import Seo from "../components/seo"
 
 const recommendations = [
   {
-    "firstName": "Jochem",
-    "lastName": "Klingeler",
-    "Company": "KidsKonnect",
-    "jobTitle": "Back End Developer",
-    "text": "Vinit and I worked mostly on improving our salesfunnel functionality, where he did both front-end and back-end. There I have seen him work in both React and Laravel, while he also did Python at Social-Schools. This shows Vinits versatility and drive to dive into sometimes unfamiliar territory. I found Vinit to be quite social, not afraid to ask and have smalltalk outside of work related questions.",
-    "creationDate": "12/02/24",
-    "status": "VISIBLE"
+    firstName: "Jochem",
+    lastName: "Klingeler",
+    Company: "KidsKonnect",
+    jobTitle: "Back End Developer",
+    text: "Vinit and I worked mostly on improving our salesfunnel functionality, where he did both front-end and back-end. There I have seen him work in both React and Laravel, while he also did Python at Social-Schools. This shows Vinits versatility and drive to dive into sometimes unfamiliar territory. I found Vinit to be quite social, not afraid to ask and have smalltalk outside of work related questions.",
+    creationDate: "12/02/24",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Eric",
-    "lastName": "de Haan",
-    "Company": "",
-    "jobTitle": "Back-end Developer",
-    "text": "I had the pleasure of working with Vinit during his time at our company. Although we worked on different projects, his passion and adaptability is seen by anyone. He's a skilled cross-platform engineer with a curiosity for new technologies. I remember his quick dive into Go-lang as one example of how he picked up challenges. He has a great technical mind and consistently demonstrates that. He would be an asset to any team looking for someone who has the technical expertise and the drive to innovate. He gets the work done.",
-    "creationDate": "10/10/24",
-    "status": "VISIBLE"
+    firstName: "Eric",
+    lastName: "de Haan",
+    Company: "",
+    jobTitle: "Back-end Developer",
+    text: "I had the pleasure of working with Vinit during his time at our company. Although we worked on different projects, his passion and adaptability is seen by anyone. He's a skilled cross-platform engineer with a curiosity for new technologies. I remember his quick dive into Go-lang as one example of how he picked up challenges. He has a great technical mind and consistently demonstrates that. He would be an asset to any team looking for someone who has the technical expertise and the drive to innovate. He gets the work done.",
+    creationDate: "10/10/24",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Anand",
-    "lastName": "Sabale",
-    "Company": "SageOne Investment Managers LLP",
-    "jobTitle": "Chief Quant Strategist",
-    "text": "Vinit excels in Python, Django, and SQL database technologies, consistently delivering high-quality solutions. His technical acumen, particularly in full-stack development, has been instrumental in streamlining our project workflows. Vinit's problem-solving skills and ability to optimize complex systems have significantly enhanced our project's efficiency. His dedication to continuous learning and adaptability make him an invaluable asset to any technical team.",
-    "creationDate": "10/08/24",
-    "status": "VISIBLE"
+    firstName: "Anand",
+    lastName: "Sabale",
+    Company: "SageOne Investment Managers LLP",
+    jobTitle: "Chief Quant Strategist",
+    text: "Vinit excels in Python, Django, and SQL database technologies, consistently delivering high-quality solutions. His technical acumen, particularly in full-stack development, has been instrumental in streamlining our project workflows. Vinit's problem-solving skills and ability to optimize complex systems have significantly enhanced our project's efficiency. His dedication to continuous learning and adaptability make him an invaluable asset to any technical team.",
+    creationDate: "10/08/24",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Ruben",
-    "lastName": "Stolk",
-    "Company": "Capptions",
-    "jobTitle": "Founder and CTO",
-    "text": "Vinit is a dedicated, hardworking individual who is always willing to roll up his sleeves and get things done. Over the years, I've had the pleasure of watching him grow and excel in various areas, and I would highly recommend him as a reliable and loyal team member.",
-    "creationDate": "10/02/24, 06:48 PM",
-    "status": "VISIBLE"
+    firstName: "Ruben",
+    lastName: "Stolk",
+    Company: "Capptions",
+    jobTitle: "Founder and CTO",
+    text: "Vinit is a dedicated, hardworking individual who is always willing to roll up his sleeves and get things done. Over the years, I've had the pleasure of watching him grow and excel in various areas, and I would highly recommend him as a reliable and loyal team member.",
+    creationDate: "10/02/24, 06:48 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Jeroen",
-    "lastName": "Stolp",
-    "Company": "KidsKonnect",
-    "jobTitle": "DevOps Eco-System Engineer",
-    "text": "I'd hire Vinit if I'm looking for a solid team player to maintain my Django/Python apps! During my time collaborating on various projects with him, he's proven to be an invaluable dev who is easy to reach and communicate with.  There were no issues whatsoever when we worked asynchronously or in different time zones. He has also demonstrated his ability to quickly learn new techniques and work with a variety of tools, developing full-stack solutions (Database/PHP/Node/React).",
-    "creationDate": "10/02/24, 12:35 PM",
-    "status": "VISIBLE"
+    firstName: "Jeroen",
+    lastName: "Stolp",
+    Company: "KidsKonnect",
+    jobTitle: "DevOps Eco-System Engineer",
+    text: "I'd hire Vinit if I'm looking for a solid team player to maintain my Django/Python apps! During my time collaborating on various projects with him, he's proven to be an invaluable dev who is easy to reach and communicate with.  There were no issues whatsoever when we worked asynchronously or in different time zones. He has also demonstrated his ability to quickly learn new techniques and work with a variety of tools, developing full-stack solutions (Database/PHP/Node/React).",
+    creationDate: "10/02/24, 12:35 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Jos",
-    "lastName": "van Velzen",
-    "Company": "KidsKonnect",
-    "jobTitle": "Software Architect",
-    "text": "I recommend Vinit for his loyalty and dedication. He brings solid experience in Python and Django and is always eager to expand his knowledge and take on new challenges. Vinit is a reliable team member who consistently contributes positively to the team. With the right guidance, I’m confident he will continue to grow as a developer.",
-    "creationDate": "10/02/24, 11:45 AM",
-    "status": "VISIBLE"
+    firstName: "Jos",
+    lastName: "van Velzen",
+    Company: "KidsKonnect",
+    jobTitle: "Software Architect",
+    text: "I recommend Vinit for his loyalty and dedication. He brings solid experience in Python and Django and is always eager to expand his knowledge and take on new challenges. Vinit is a reliable team member who consistently contributes positively to the team. With the right guidance, I’m confident he will continue to grow as a developer.",
+    creationDate: "10/02/24, 11:45 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Joost",
-    "lastName": "Mundi",
-    "Company": "KidsKonnect",
-    "jobTitle": "Customer Support Specialist",
-    "text": "Vinit is a great coder, with a lot of knowledge in Django/Python. When having issues with the CMS, you can always depend on Vinit on finding and solving the issue. He has taught me many things over the years about the backend and is very patient when passing on his skills.",
-    "creationDate": "09/30/24, 04:36 PM",
-    "status": "VISIBLE"
+    firstName: "Joost",
+    lastName: "Mundi",
+    Company: "KidsKonnect",
+    jobTitle: "Customer Support Specialist",
+    text: "Vinit is a great coder, with a lot of knowledge in Django/Python. When having issues with the CMS, you can always depend on Vinit on finding and solving the issue. He has taught me many things over the years about the backend and is very patient when passing on his skills.",
+    creationDate: "09/30/24, 04:36 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Cengiz",
-    "lastName": "Karadeniz",
-    "Company": "KidsKonnect",
-    "jobTitle": "Quality Engineer",
-    "text": "Working with Vinit has been really nice. He's super smart in tech stuff, and I've learned a lot from him. Vinit is not just really good at tech things; he's also patient and positive, which makes our team better. He's great at handling tough problems calmly and thinking ahead. Besides his tech skills, Vinit is a good team player who makes our work environment positive. It's cool to work with someone who's not only good at programming but also encourages us to keep learning and working together. Working with Vinit has been a really good experience.",
-    "creationDate": "11/10/23, 04:39 PM",
-    "status": "VISIBLE"
+    firstName: "Cengiz",
+    lastName: "Karadeniz",
+    Company: "KidsKonnect",
+    jobTitle: "Quality Engineer",
+    text: "Working with Vinit has been really nice. He's super smart in tech stuff, and I've learned a lot from him. Vinit is not just really good at tech things; he's also patient and positive, which makes our team better. He's great at handling tough problems calmly and thinking ahead. Besides his tech skills, Vinit is a good team player who makes our work environment positive. It's cool to work with someone who's not only good at programming but also encourages us to keep learning and working together. Working with Vinit has been a really good experience.",
+    creationDate: "11/10/23, 04:39 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Yuri",
-    "lastName": "Ramalho Rech",
-    "Company": "KidsKonnect",
-    "jobTitle": "Software Engineer",
-    "text": "Working with Vinit has been a pleasure. He is so professional and has a brilliant mind, capable of solving the most complicated problems. He is dynamic and always keeps in mind the big picture in everything he does. He has excellent leadership skills. I've been learning a lot from him and I hope to keep collaborating with him for a long time.",
-    "creationDate": "10/31/23, 07:43 AM",
-    "status": "VISIBLE"
+    firstName: "Yuri",
+    lastName: "Ramalho Rech",
+    Company: "KidsKonnect",
+    jobTitle: "Software Engineer",
+    text: "Working with Vinit has been a pleasure. He is so professional and has a brilliant mind, capable of solving the most complicated problems. He is dynamic and always keeps in mind the big picture in everything he does. He has excellent leadership skills. I've been learning a lot from him and I hope to keep collaborating with him for a long time.",
+    creationDate: "10/31/23, 07:43 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Bert",
-    "lastName": "van 't Land",
-    "Company": "Schoolfruit.nl",
-    "jobTitle": "Interim-management",
-    "text": "I worked together with Vinit for almost eight years. We started as a small startup. We didn't have much clients and we were still pretty green behind the ears. But now eight years later we offer a grown up communication platform to 50% of the primary schools in the Netherlands. Vinit played an important roll in this achievement.   Vinit is a dedicated developer. He can work autonomously and is dedicated to solve the problem. He is also very reliable and easy work with.   If you are looking for a reliable and professional person for your team than i would definitely recommend Vinit.",
-    "creationDate": "01/31/23, 03:08 PM",
-    "status": "VISIBLE"
+    firstName: "Bert",
+    lastName: "van 't Land",
+    Company: "Schoolfruit.nl",
+    jobTitle: "Interim-management",
+    text: "I worked together with Vinit for almost eight years. We started as a small startup. We didn't have much clients and we were still pretty green behind the ears. But now eight years later we offer a grown up communication platform to 50% of the primary schools in the Netherlands. Vinit played an important roll in this achievement.   Vinit is a dedicated developer. He can work autonomously and is dedicated to solve the problem. He is also very reliable and easy work with.   If you are looking for a reliable and professional person for your team than i would definitely recommend Vinit.",
+    creationDate: "01/31/23, 03:08 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Florian",
-    "lastName": "Delizy",
-    "Company": "FiduciaEdge Technologies Co., Ltd.",
-    "jobTitle": "Director of Research Development",
-    "text": "I have been working with Vinit on django CMS for a while. Vinit had been instrumental in pushing for PR reviews &merges, debugging through some quite tricky situations, and generally shown great expertise in django, github CI, release processes, and generally web application development.",
-    "creationDate": "12/02/22, 07:45 PM",
-    "status": "VISIBLE"
+    firstName: "Florian",
+    lastName: "Delizy",
+    Company: "FiduciaEdge Technologies Co., Ltd.",
+    jobTitle: "Director of Research Development",
+    text: "I have been working with Vinit on django CMS for a while. Vinit had been instrumental in pushing for PR reviews &merges, debugging through some quite tricky situations, and generally shown great expertise in django, github CI, release processes, and generally web application development.",
+    creationDate: "12/02/22, 07:45 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Fabian",
-    "lastName": "Braun",
-    "Company": "django CMS Association",
-    "jobTitle": "Django CMS Fellow",
-    "text": "It's a pleasure to work with Vinit! He's a key contributor to the open source project django CMS.   When working together he always went the extra mile to find and implement the best solution for the community. He's extremely knowledgable in Python, Django, and, of course, django CMS.   I appreciate his ability to abstract issues, find the underlying structures, develop general solutions that not only fix the issue but contribute to making the overall platform more powerful.",
-    "creationDate": "10/17/22, 01:43 PM",
-    "status": "VISIBLE"
+    firstName: "Fabian",
+    lastName: "Braun",
+    Company: "django CMS Association",
+    jobTitle: "Django CMS Fellow",
+    text: "It's a pleasure to work with Vinit! He's a key contributor to the open source project django CMS.   When working together he always went the extra mile to find and implement the best solution for the community. He's extremely knowledgable in Python, Django, and, of course, django CMS.   I appreciate his ability to abstract issues, find the underlying structures, develop general solutions that not only fix the issue but contribute to making the overall platform more powerful.",
+    creationDate: "10/17/22, 01:43 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Nicolai",
-    "lastName": "Ridani",
-    "Company": "DigitalService",
-    "jobTitle": "Growth Manager",
-    "text": "Vinit has been a core member of the django CMS open source community for many years. His contribution plays an important role in the success of django CMS, one of the leading open source content management systems in the Django ecosystem. Thanks to his expertise and team spirit, he is highly appreciated by many members. In addition to reviewing PRs, Vinit also regularly participates in the Tech Committee and is involved in strategic decisions. We consider ourselves fortunate to have Vinit as part of our community and look forward to many more years of collaboration.",
-    "creationDate": "10/17/22, 11:47 AM",
-    "status": "VISIBLE"
+    firstName: "Nicolai",
+    lastName: "Ridani",
+    Company: "DigitalService",
+    jobTitle: "Growth Manager",
+    text: "Vinit has been a core member of the django CMS open source community for many years. His contribution plays an important role in the success of django CMS, one of the leading open source content management systems in the Django ecosystem. Thanks to his expertise and team spirit, he is highly appreciated by many members. In addition to reviewing PRs, Vinit also regularly participates in the Tech Committee and is involved in strategic decisions. We consider ourselves fortunate to have Vinit as part of our community and look forward to many more years of collaboration.",
+    creationDate: "10/17/22, 11:47 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Mark",
-    "lastName": "Walker",
-    "Company": "ISM Fantasy Games",
-    "jobTitle": "Senior Software Developer",
-    "text": "Vinit is a key member of the core django-cms team, helping to review PRs from other contributors as well as implementing features & fixes to help our projects progress. Vinit is also an asset on our Slack network, helping out with support requests to solve problems or point people in the right direction if that's more appropriate.",
-    "creationDate": "09/28/22, 01:11 AM",
-    "status": "VISIBLE"
+    firstName: "Mark",
+    lastName: "Walker",
+    Company: "ISM Fantasy Games",
+    jobTitle: "Senior Software Developer",
+    text: "Vinit is a key member of the core django-cms team, helping to review PRs from other contributors as well as implementing features & fixes to help our projects progress. Vinit is also an asset on our Slack network, helping out with support requests to solve problems or point people in the right direction if that's more appropriate.",
+    creationDate: "09/28/22, 01:11 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Madhavi",
-    "lastName": "Solanki",
-    "Company": "Cyphertree Technologies Pvt Ltd",
-    "jobTitle": "Founder",
-    "text": "Vinit has been a great mentor to the Cyphertree tech team. His approach has helped to solve complex tech problems. He simplifies the problem and breaks it down for the team to understand the importance of progressive development. We at the Cyphertree team truly appreciate his hard work and guidance throughout the project and looking forward to keeping working with Vinit. All the best.",
-    "creationDate": "06/22/21, 11:55 AM",
-    "status": "VISIBLE"
+    firstName: "Madhavi",
+    lastName: "Solanki",
+    Company: "Cyphertree Technologies Pvt Ltd",
+    jobTitle: "Founder",
+    text: "Vinit has been a great mentor to the Cyphertree tech team. His approach has helped to solve complex tech problems. He simplifies the problem and breaks it down for the team to understand the importance of progressive development. We at the Cyphertree team truly appreciate his hard work and guidance throughout the project and looking forward to keeping working with Vinit. All the best.",
+    creationDate: "06/22/21, 11:55 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Riyaz",
-    "lastName": "Kagzi",
-    "Company": "Taghash",
-    "jobTitle": "Senior Software Engineer",
-    "text": "Vinit is a really talented engineer with an extensive experience in the field. He is a self-motivated individual, and an awesome mentor who's always there to help you out. We've only worked together for a few months (as of writing) but his ideas and approach has already influenced me and impacted the way I approach things (considering we've only been communicating remotely, that's even better!)  When it comes to building software, his approach is very logical and pragmatic, and his solutions are really well-built!  I’m glad to have an opportunity to interact with him and I wish our paths cross again in the future.",
-    "creationDate": "02/11/21, 05:52 PM",
-    "status": "VISIBLE"
+    firstName: "Riyaz",
+    lastName: "Kagzi",
+    Company: "Taghash",
+    jobTitle: "Senior Software Engineer",
+    text: "Vinit is a really talented engineer with an extensive experience in the field. He is a self-motivated individual, and an awesome mentor who's always there to help you out. We've only worked together for a few months (as of writing) but his ideas and approach has already influenced me and impacted the way I approach things (considering we've only been communicating remotely, that's even better!)  When it comes to building software, his approach is very logical and pragmatic, and his solutions are really well-built!  I’m glad to have an opportunity to interact with him and I wish our paths cross again in the future.",
+    creationDate: "02/11/21, 05:52 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Shubham",
-    "lastName": "Pathak",
-    "Company": "ProMobi Technologies",
-    "jobTitle": "Lead Security",
-    "text": "Vinit is an inspirational and motivated person who has extensive experience in software development and DevOps practices. He has excellent knowledge of different operating systems and languages.   Vinit performs complex tasks in a dedicated manner and has the integrity to help others. Sometimes even a causal chat helps you learn something new from him.",
-    "creationDate": "09/10/19, 07:31 PM",
-    "status": "VISIBLE"
+    firstName: "Shubham",
+    lastName: "Pathak",
+    Company: "ProMobi Technologies",
+    jobTitle: "Lead Security",
+    text: "Vinit is an inspirational and motivated person who has extensive experience in software development and DevOps practices. He has excellent knowledge of different operating systems and languages.   Vinit performs complex tasks in a dedicated manner and has the integrity to help others. Sometimes even a causal chat helps you learn something new from him.",
+    creationDate: "09/10/19, 07:31 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Anit",
-    "lastName": "Rai",
-    "Company": "Prosperix",
-    "jobTitle": "System Architect | Coder",
-    "text": "Vinit has a very pragmatic approach towards offering solutions. Where most architects try to tackle the Goliath on day one, Vinit prefers to solve the core piece of the puzzle and eventually architect upon it. This has led him to build some of the robust systems in Social Schools which are scalable even after years.",
-    "creationDate": "08/21/19, 12:06 PM",
-    "status": "VISIBLE"
+    firstName: "Anit",
+    lastName: "Rai",
+    Company: "Prosperix",
+    jobTitle: "System Architect | Coder",
+    text: "Vinit has a very pragmatic approach towards offering solutions. Where most architects try to tackle the Goliath on day one, Vinit prefers to solve the core piece of the puzzle and eventually architect upon it. This has led him to build some of the robust systems in Social Schools which are scalable even after years.",
+    creationDate: "08/21/19, 12:06 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Anay",
-    "lastName": "Kamat",
-    "Company": "Equal Experts",
-    "jobTitle": "Lead Software Consultant",
-    "text": "Vinit is hands-on on Python and other Agile concepts like Continuous Integration and Continuous Delivery. He has been a great team member to work with and quite comfortable to work remotely as well.",
-    "creationDate": "01/24/19, 02:46 PM",
-    "status": "VISIBLE"
+    firstName: "Anay",
+    lastName: "Kamat",
+    Company: "Equal Experts",
+    jobTitle: "Lead Software Consultant",
+    text: "Vinit is hands-on on Python and other Agile concepts like Continuous Integration and Continuous Delivery. He has been a great team member to work with and quite comfortable to work remotely as well.",
+    creationDate: "01/24/19, 02:46 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Swapnil",
-    "lastName": "Narkhede",
-    "Company": "CARIAD",
-    "jobTitle": "Senior Software Engineer",
-    "text": "Vinit Kumar is a very talented and passionate programmer, who knows how thing needs to be done. He is an expert in python development. He is a good team member, self-motivated, very sound in technical knowledge. He is a good mentor and always keen to learn new things.",
-    "creationDate": "12/21/18, 04:35 PM",
-    "status": "VISIBLE"
+    firstName: "Swapnil",
+    lastName: "Narkhede",
+    Company: "CARIAD",
+    jobTitle: "Senior Software Engineer",
+    text: "Vinit Kumar is a very talented and passionate programmer, who knows how thing needs to be done. He is an expert in python development. He is a good team member, self-motivated, very sound in technical knowledge. He is a good mentor and always keen to learn new things.",
+    creationDate: "12/21/18, 04:35 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Rutvij",
-    "lastName": "Pandya",
-    "Company": "Pattern®",
-    "jobTitle": "Principal Software Engineer",
-    "text": "Vinit is the one with all qualities you look for - A great team player, self-motivated, a very patient mentor, dedicated, logically very sound with abilities to solve problems, learns new things and shares with the team. He has it all! He can be the 'go-to' man in the team.  I’m glad to have an opportunity to interact with him and I wish our paths cross again in the future.",
-    "creationDate": "12/17/18, 04:43 PM",
-    "status": "VISIBLE"
+    firstName: "Rutvij",
+    lastName: "Pandya",
+    Company: "Pattern®",
+    jobTitle: "Principal Software Engineer",
+    text: "Vinit is the one with all qualities you look for - A great team player, self-motivated, a very patient mentor, dedicated, logically very sound with abilities to solve problems, learns new things and shares with the team. He has it all! He can be the 'go-to' man in the team.  I’m glad to have an opportunity to interact with him and I wish our paths cross again in the future.",
+    creationDate: "12/17/18, 04:43 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Saurabh",
-    "lastName": "Bajaj",
-    "Company": "Harman Connected Services Corp India Pvt Ltd",
-    "jobTitle": "Architect (iOS)",
-    "text": "I and Vinit work for different companies but from the same location. Vinit has been guiding me for few months and I have seen a tremendous change in my software development skills. Vinit is someone who likes to have a detailed plan before jumping to the development state. His approach towards software development and debugging issues is excellent. He asks right questions in a right way thus leading us to the point which he wants to convey. Whenever Vinit recommends anything, he supports it with a detailed explanation and also explains why it is the best. He is a gem to my learning curve :)",
-    "creationDate": "06/18/18, 07:46 AM",
-    "status": "VISIBLE"
+    firstName: "Saurabh",
+    lastName: "Bajaj",
+    Company: "Harman Connected Services Corp India Pvt Ltd",
+    jobTitle: "Architect (iOS)",
+    text: "I and Vinit work for different companies but from the same location. Vinit has been guiding me for few months and I have seen a tremendous change in my software development skills. Vinit is someone who likes to have a detailed plan before jumping to the development state. His approach towards software development and debugging issues is excellent. He asks right questions in a right way thus leading us to the point which he wants to convey. Whenever Vinit recommends anything, he supports it with a detailed explanation and also explains why it is the best. He is a gem to my learning curve :)",
+    creationDate: "06/18/18, 07:46 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Edwin",
-    "lastName": "Janssen",
-    "Company": "KidsKonnect",
-    "jobTitle": "Senior Product Owner",
-    "text": "Vinit his qualties do not stop at being a very good programmer. His mentality is one many people will die for. He breaths programming and is always keen to learn new things.   Vinit is also a great collegue. Working together with him is a privilege. He is always prompt when you need him. And always thinks with you and doesn't hesitate to share his knowledge with you.  Overall working with Vinit is just great.",
-    "creationDate": "01/24/18, 08:37 PM",
-    "status": "VISIBLE"
+    firstName: "Edwin",
+    lastName: "Janssen",
+    Company: "KidsKonnect",
+    jobTitle: "Senior Product Owner",
+    text: "Vinit his qualties do not stop at being a very good programmer. His mentality is one many people will die for. He breaths programming and is always keen to learn new things.   Vinit is also a great collegue. Working together with him is a privilege. He is always prompt when you need him. And always thinks with you and doesn't hesitate to share his knowledge with you.  Overall working with Vinit is just great.",
+    creationDate: "01/24/18, 08:37 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Shanice Celsa",
-    "lastName": "Tan",
-    "Company": "GET IN CTRL. Hosting",
-    "jobTitle": "Groene Wordpress Hosting Manager",
-    "text": "It is with great joy to recommend Vinit Kumar. Vinit is a very skilled web programmer. He has the ability to effectively listen and he highly contributed to the Social Schools websites with his excellent skills in Python and Django. He is available when needed and is extremely prompt. He completes what he tells you he will complete. He also cares about his colleagues, and takes the time to explain and answer questions may you require assistance in programming.  Vinit is an exceptional web programmer and a very pleasant person to work with.",
-    "creationDate": "10/20/17, 07:43 PM",
-    "status": "VISIBLE"
+    firstName: "Shanice Celsa",
+    lastName: "Tan",
+    Company: "GET IN CTRL. Hosting",
+    jobTitle: "Groene Wordpress Hosting Manager",
+    text: "It is with great joy to recommend Vinit Kumar. Vinit is a very skilled web programmer. He has the ability to effectively listen and he highly contributed to the Social Schools websites with his excellent skills in Python and Django. He is available when needed and is extremely prompt. He completes what he tells you he will complete. He also cares about his colleagues, and takes the time to explain and answer questions may you require assistance in programming.  Vinit is an exceptional web programmer and a very pleasant person to work with.",
+    creationDate: "10/20/17, 07:43 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Robert",
-    "lastName": "Cooper",
-    "Company": "BaseDash",
-    "jobTitle": "Full Stack Developer",
-    "text": "Vinit has been a mentor for me when it comes to learning best practices related to web development. We've both been contributing to an open source project (one that he started himself) and has been providing me with guidance related to how I should put together pull requests, how issues should be tracked, and a bunch of other tips. When Vinit recommends a certain approach, he does so by explaining the reasoning behind it and why it is likely the \"best\" approach to take. It's been great collaborating with Vinit and I'm sure i'll continue to learn a lot from him.",
-    "creationDate": "10/20/17, 07:22 PM",
-    "status": "VISIBLE"
+    firstName: "Robert",
+    lastName: "Cooper",
+    Company: "BaseDash",
+    jobTitle: "Full Stack Developer",
+    text: "Vinit has been a mentor for me when it comes to learning best practices related to web development. We've both been contributing to an open source project (one that he started himself) and has been providing me with guidance related to how I should put together pull requests, how issues should be tracked, and a bunch of other tips. When Vinit recommends a certain approach, he does so by explaining the reasoning behind it and why it is likely the \"best\" approach to take. It's been great collaborating with Vinit and I'm sure i'll continue to learn a lot from him.",
+    creationDate: "10/20/17, 07:22 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Parth",
-    "lastName": "Desai",
-    "Company": "Moonsong Labs",
-    "jobTitle": "Principal Software Engineer",
-    "text": "Vinit is a great developer, and one of a few who has genuine passion for software development. We joined company at same time, And I've always been impressed with his software development methodologies and sound computer science concepts. He is an asset to our company.",
-    "creationDate": "05/04/15, 03:43 PM",
-    "status": "VISIBLE"
+    firstName: "Parth",
+    lastName: "Desai",
+    Company: "Moonsong Labs",
+    jobTitle: "Principal Software Engineer",
+    text: "Vinit is a great developer, and one of a few who has genuine passion for software development. We joined company at same time, And I've always been impressed with his software development methodologies and sound computer science concepts. He is an asset to our company.",
+    creationDate: "05/04/15, 03:43 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Robert",
-    "lastName": "Korteland",
-    "Company": "KidsKonnect",
-    "jobTitle": "Senior productmanager",
-    "text": "Vinit is an incredibly dedicated and friendly person. His passion for software development is admirable and he is very eager to learn more.",
-    "creationDate": "01/02/15, 03:41 PM",
-    "status": "VISIBLE"
+    firstName: "Robert",
+    lastName: "Korteland",
+    Company: "KidsKonnect",
+    jobTitle: "Senior productmanager",
+    text: "Vinit is an incredibly dedicated and friendly person. His passion for software development is admirable and he is very eager to learn more.",
+    creationDate: "01/02/15, 03:41 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Subhojit",
-    "lastName": "Paul",
-    "Company": "Publicis Sapient",
-    "jobTitle": "Senior Associate Technology L2",
-    "text": "Vinit is very dynamic. He supports open source technologies. He approaches problems from the base, he plans how to solve the problem before actually getting started to solve it. I liked that he studies about algorithms and stuffs like that. He plays good role in building open source.    He has helped me many times in Python. What I liked about him is he likes to learn new technologies, and insipire/help others.",
-    "creationDate": "11/13/14, 04:05 PM",
-    "status": "VISIBLE"
+    firstName: "Subhojit",
+    lastName: "Paul",
+    Company: "Publicis Sapient",
+    jobTitle: "Senior Associate Technology L2",
+    text: "Vinit is very dynamic. He supports open source technologies. He approaches problems from the base, he plans how to solve the problem before actually getting started to solve it. I liked that he studies about algorithms and stuffs like that. He plays good role in building open source.    He has helped me many times in Python. What I liked about him is he likes to learn new technologies, and insipire/help others.",
+    creationDate: "11/13/14, 04:05 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Angvish",
-    "lastName": "Kumar",
-    "Company": "Tavisca, a cxLoyalty Technology Platform (Division of JP Morgan Chase & Co.)",
-    "jobTitle": "Technical Lead",
-    "text": "Vinit has built a strong (and deserved) reputation as someone with vision, diligence and honour – he is someone who gets things done! His focus keeps everything moving smoothly, he makes sure all the deadlines are met, and makes sure that whatever project he is working on meets the highest standards.",
-    "creationDate": "11/12/14, 12:21 PM",
-    "status": "VISIBLE"
+    firstName: "Angvish",
+    lastName: "Kumar",
+    Company:
+      "Tavisca, a cxLoyalty Technology Platform (Division of JP Morgan Chase & Co.)",
+    jobTitle: "Technical Lead",
+    text: "Vinit has built a strong (and deserved) reputation as someone with vision, diligence and honour – he is someone who gets things done! His focus keeps everything moving smoothly, he makes sure all the deadlines are met, and makes sure that whatever project he is working on meets the highest standards.",
+    creationDate: "11/12/14, 12:21 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Henk-Jan",
-    "lastName": "Verkerk",
-    "Company": "ADP",
-    "jobTitle": "Senior Manager Product Management",
-    "text": "I have seen Vinit growing as a professional at Changer. He asks the right questions, has a problem solving mind and works hard. He contributed greatly in the support activities we worked on together, which has led to customer satisfaction.",
-    "creationDate": "10/27/14, 09:25 AM",
-    "status": "VISIBLE"
+    firstName: "Henk-Jan",
+    lastName: "Verkerk",
+    Company: "ADP",
+    jobTitle: "Senior Manager Product Management",
+    text: "I have seen Vinit growing as a professional at Changer. He asks the right questions, has a problem solving mind and works hard. He contributed greatly in the support activities we worked on together, which has led to customer satisfaction.",
+    creationDate: "10/27/14, 09:25 AM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Piper",
-    "lastName": "Chester",
-    "Company": "Spotify",
-    "jobTitle": "Software Engineer",
-    "text": "Vinit is fantastic to work with. We've co-developed a couple different open source projects together and he's always been helpful, knowledgeable, friendly, and committed. He's a great partner and I'd recommend him to any team that's looking for a productive and engaged developer.",
-    "creationDate": "04/28/14, 03:32 PM",
-    "status": "VISIBLE"
+    firstName: "Piper",
+    lastName: "Chester",
+    Company: "Spotify",
+    jobTitle: "Software Engineer",
+    text: "Vinit is fantastic to work with. We've co-developed a couple different open source projects together and he's always been helpful, knowledgeable, friendly, and committed. He's a great partner and I'd recommend him to any team that's looking for a productive and engaged developer.",
+    creationDate: "04/28/14, 03:32 PM",
+    status: "VISIBLE",
   },
   {
-    "firstName": "Debjit (Dev)",
-    "lastName": "Saha",
-    "Company": "HomeAbroad Inc.",
-    "jobTitle": "Co-Founder",
-    "text": "Vinit is a hard-working software developer, possesses the ability to grasp new technology quickly and apply them to on-going projects. Avid Self-learner and highly motivated.",
-    "creationDate": "10/31/13, 03:02 AM",
-    "status": "VISIBLE"
-  }
+    firstName: "Debjit (Dev)",
+    lastName: "Saha",
+    Company: "HomeAbroad Inc.",
+    jobTitle: "Co-Founder",
+    text: "Vinit is a hard-working software developer, possesses the ability to grasp new technology quickly and apply them to on-going projects. Avid Self-learner and highly motivated.",
+    creationDate: "10/31/13, 03:02 AM",
+    status: "VISIBLE",
+  },
+]
 
-];
+const parseRecommendationDate = (value) => {
+  const [datePart] = value.split(",")
+  const [month, day, year] = datePart.split("/").map(Number)
+  const fullYear = year < 100 ? 2000 + year : year
+
+  return new Date(fullYear, month - 1, day)
+}
+
+const formatRecommendationDate = (value) =>
+  parseRecommendationDate(value).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+
+const getInitials = (rec) =>
+  `${rec.firstName?.[0] || ""}${rec.lastName?.[0] || ""}`.toUpperCase()
+
+const getPersonName = (rec) => `${rec.firstName} ${rec.lastName}`.trim()
+
+const getRoleLine = (rec) =>
+  [rec.jobTitle, rec.Company].filter(Boolean).join(" at ")
+
+const themeSignals = [
+  {
+    label: "Systems builder",
+    terms: ["django", "python", "systems", "architecture", "technical"],
+  },
+  {
+    label: "Mentor",
+    terms: ["mentor", "guidance", "learned", "taught", "help"],
+  },
+  {
+    label: "Reliable teammate",
+    terms: ["reliable", "team", "collaborating", "collaboration", "remote"],
+  },
+  {
+    label: "Pragmatic problem solver",
+    terms: ["problem", "solve", "debugging", "pragmatic", "approach"],
+  },
+]
 
 const ValueComponent = (props) => {
   const data = useStaticQuery(graphql`
@@ -308,50 +350,148 @@ const ValueComponent = (props) => {
   `)
 
   const { title } = data.site.siteMetadata
+  const sortedRecommendations = [...recommendations].sort(
+    (a, b) =>
+      parseRecommendationDate(b.creationDate) -
+      parseRecommendationDate(a.creationDate)
+  )
+  const companies = new Set(
+    recommendations.map((rec) => rec.Company).filter(Boolean)
+  )
+  const years = recommendations.map((rec) =>
+    parseRecommendationDate(rec.creationDate).getFullYear()
+  )
+  const startYear = Math.min(...years)
+  const endYear = Math.max(...years)
+  const spotlightRecommendations = sortedRecommendations.slice(0, 3)
+  const themeCounts = themeSignals.map((theme) => ({
+    ...theme,
+    count: recommendations.filter((rec) => {
+      const text = rec.text.toLowerCase()
+      return theme.terms.some((term) => text.includes(term))
+    }).length,
+  }))
 
   return (
     <Layout location={props.location} title={title}>
-      <Seo title="Recommendations" />
+      <Seo
+        title="Recommendations"
+        description="Recommendations from colleagues, founders, engineers, product leaders, and open source collaborators who have worked with Vinit Kumar."
+        pathname={props.location.pathname}
+      />
       <div className="recommendations-container">
-        <h1 className="heading">What my colleagues say about working with me</h1>
-        
-        <div className="tldr-section">
-          <h2 className="tldr-title">TL;DR</h2>
-          <ul className="tldr-list">
-            <li><strong>Full-stack polyglot</strong> — Python, Django, React, Go, Laravel, DevOps</li>
-            <li><strong>Django CMS core team member</strong></li>
-            <li><strong>Patient mentor</strong> who breaks down complex problems</li>
-            <li><strong>Remote collaboration expert</strong> across time zones</li>
-            <li><strong>Pragmatic problem-solver</strong> with startup-to-scale experience</li>
-            <li><strong>Quality-focused delivery</strong> that gets things done</li>
-            <li><strong>Strategic thinker</strong> with proven leadership skills</li>
-            <li><strong>Continuous learner</strong> who adapts quickly</li>
-          </ul>
-        </div>
-            <div className="recommendations-grid">
-              {recommendations.map((rec, index) => (
-                <div className="recommendation-card" key={index}>
-                  <div className="recommendation-header">
-                    <div className="avatar">
-                      {rec.firstName[0] + rec.lastName[0]}
-                    </div>
-                    <div className="info">
-                      <h3 className="name">
-                        {rec.firstName} {rec.lastName}
-                      </h3>
-                      <p className="job-title">{rec.jobTitle} at {rec.Company}</p>
-                    </div>
-                  </div>
-                  <p className="recommendation-text">{rec.text}</p>
-                  <p className="creation-date">
-                    {new Date(rec.creationDate).toLocaleDateString()}
-                  </p>
-                </div>
-              ))}
+        <header className="recommendations-hero">
+          <p className="eyebrow">Recommendations</p>
+          <h1>What colleagues say after working with me.</h1>
+          <p>
+            A decade-plus record from founders, product leaders, engineers, open
+            source maintainers, support teams, and mentees across startups,
+            remote teams, and community projects.
+          </p>
+        </header>
+
+        <section
+          className="recommendation-metrics"
+          aria-label="Recommendation summary"
+        >
+          <div>
+            <strong>{recommendations.length}</strong>
+            <span>recommendations</span>
+          </div>
+          <div>
+            <strong>{companies.size}</strong>
+            <span>organizations</span>
+          </div>
+          <div>
+            <strong>
+              {startYear}-{endYear}
+            </strong>
+            <span>working history</span>
+          </div>
+        </section>
+
+        <section className="recommendation-themes">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Recurring Signals</p>
+              <h2>Patterns across the recommendations</h2>
             </div>
           </div>
-        </Layout>
-    )
+          <div className="recommendation-theme-grid">
+            {themeCounts.map((theme) => (
+              <div className="recommendation-theme" key={theme.label}>
+                <span>{theme.count}</span>
+                <strong>{theme.label}</strong>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="recommendation-spotlight">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Recent Proof</p>
+              <h2>Selected recommendations</h2>
+            </div>
+          </div>
+          <div className="recommendation-spotlight-grid">
+            {spotlightRecommendations.map((rec) => (
+              <article
+                className="recommendation-spotlight-card"
+                key={`${rec.firstName}-${rec.lastName}-${rec.creationDate}`}
+              >
+                <blockquote>{rec.text}</blockquote>
+                <footer>
+                  <div className="avatar" aria-hidden="true">
+                    {getInitials(rec)}
+                  </div>
+                  <div>
+                    <strong>{getPersonName(rec)}</strong>
+                    <span>{getRoleLine(rec)}</span>
+                  </div>
+                </footer>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="recommendation-list-section">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Archive</p>
+              <h2>All recommendations</h2>
+            </div>
+          </div>
+          <div className="recommendations-list">
+            {sortedRecommendations.map((rec) => (
+              <article
+                className="recommendation-row"
+                key={`${rec.firstName}-${rec.lastName}-${rec.creationDate}`}
+              >
+                <div className="recommendation-person">
+                  <div className="avatar" aria-hidden="true">
+                    {getInitials(rec)}
+                  </div>
+                  <div>
+                    <h3>{getPersonName(rec)}</h3>
+                    <p>{getRoleLine(rec)}</p>
+                    <time
+                      dateTime={parseRecommendationDate(
+                        rec.creationDate
+                      ).toISOString()}
+                    >
+                      {formatRecommendationDate(rec.creationDate)}
+                    </time>
+                  </div>
+                </div>
+                <p className="recommendation-text">{rec.text}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </Layout>
+  )
 }
 
 export default ValueComponent

--- a/src/pages/recommendations.js
+++ b/src/pages/recommendations.js
@@ -374,11 +374,6 @@ const ValueComponent = (props) => {
 
   return (
     <Layout location={props.location} title={title}>
-      <Seo
-        title="Recommendations"
-        description="Recommendations from colleagues, founders, engineers, product leaders, and open source collaborators who have worked with Vinit Kumar."
-        pathname={props.location.pathname}
-      />
       <div className="recommendations-container">
         <header className="recommendations-hero">
           <p className="eyebrow">Recommendations</p>
@@ -495,3 +490,11 @@ const ValueComponent = (props) => {
 }
 
 export default ValueComponent
+
+export const Head = ({ location }) => (
+  <Seo
+    title="Recommendations"
+    description="Recommendations from colleagues, founders, engineers, product leaders, and open source collaborators who have worked with Vinit Kumar."
+    pathname={location.pathname}
+  />
+)

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -1,7 +1,8 @@
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
+import { Link, useStaticQuery, graphql } from "gatsby"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
+import { getTopicSlug } from "../utils/content"
 
 const StatsIndex = (props) => {
   const data = useStaticQuery(graphql`
@@ -147,7 +148,7 @@ const StatsIndex = (props) => {
       
       {/* Header */}
       <div style={{ marginBottom: "2rem" }}>
-        <h1>📊 Blog Analytics & Insights</h1>
+        <h1>Blog Analytics & Insights</h1>
         <p style={{ fontSize: "1.1rem", color: "var(--text-muted)", margin: 0 }}>
           A deep dive into {writingPeriodYears} years of writing, learning, and professional growth
         </p>
@@ -161,12 +162,12 @@ const StatsIndex = (props) => {
         marginBottom: "2rem"
       }}>
         {[
-          { label: "Total Posts", value: totalPosts, icon: "📝" },
-          { label: "Total Words", value: totalWords.toLocaleString(), icon: "📖" },
-          { label: "Reading Time", value: `${hoursOfContent}h`, icon: "⏱️" },
-          { label: "Avg Words/Post", value: avgWordsPerPost, icon: "📄" },
-          { label: "Writing Years", value: writingPeriodYears, icon: "📅" },
-          { label: "Posts/Year", value: avgPostsPerYear, icon: "📈" }
+          { label: "Total Posts", value: totalPosts },
+          { label: "Total Words", value: totalWords.toLocaleString() },
+          { label: "Reading Time", value: `${hoursOfContent}h` },
+          { label: "Avg Words/Post", value: avgWordsPerPost },
+          { label: "Writing Years", value: writingPeriodYears },
+          { label: "Posts/Year", value: avgPostsPerYear }
         ].map((stat, index) => (
           <div key={index} style={{
             background: "var(--background-card)",
@@ -176,7 +177,6 @@ const StatsIndex = (props) => {
             textAlign: "center",
             boxShadow: "var(--shadow-card)"
           }}>
-            <div style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>{stat.icon}</div>
             <div style={{ fontSize: "1.5rem", fontWeight: "600", color: "var(--text)" }}>{stat.value}</div>
             <div style={{ fontSize: "1rem", color: "var(--text-muted)" }}>{stat.label}</div>
           </div>
@@ -191,7 +191,7 @@ const StatsIndex = (props) => {
         marginBottom: "2rem",
         color: "white"
       }}>
-        <h2 style={{ color: "white" }}>🚀 Career Evolution Through Writing</h2>
+        <h2 style={{ color: "white" }}>Career Evolution Through Writing</h2>
         <div style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
@@ -219,7 +219,7 @@ const StatsIndex = (props) => {
         marginBottom: "2rem",
         border: "1px solid var(--gray-line)"
       }}>
-        <h2>🎯 Interesting Trivia</h2>
+        <h2>Interesting Trivia</h2>
         <div style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
@@ -254,7 +254,7 @@ const StatsIndex = (props) => {
           borderRadius: "12px",
           border: "1px solid var(--gray-line)"
         }}>
-          <h2>📈 Posts by Year</h2>
+          <h2>Posts by Year</h2>
           <div style={{ fontFamily: "monospace", fontSize: "14px", lineHeight: "1.8", color: "var(--text)" }}>
             {years.map(year => {
               const count = yearStats[year]
@@ -295,22 +295,22 @@ const StatsIndex = (props) => {
           borderRadius: "12px",
           border: "1px solid var(--gray-line)"
         }}>
-          <h2>💡 Quick Insights</h2>
+          <h2>Quick Insights</h2>
           <div style={{ fontSize: "1rem", lineHeight: "1.6", color: "var(--text)" }}>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>🔥 Most Active:</strong><br/>
+              <strong>Most Active:</strong><br/>
               {mostActiveYear} ({yearStats[mostActiveYear]} posts)
             </div>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>📅 Productive Month:</strong><br/>
+              <strong>Productive Month:</strong><br/>
               {mostProductiveMonth?.[0]} ({mostProductiveMonth?.[1]} posts)
             </div>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>📏 Post Lengths:</strong><br/>
+              <strong>Post Lengths:</strong><br/>
               {shortestPost} - {longestPost} words
             </div>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>⚡ Total Reading:</strong><br/>
+              <strong>Total Reading:</strong><br/>
               {hoursOfContent} hours of content
             </div>
           </div>
@@ -325,7 +325,7 @@ const StatsIndex = (props) => {
         border: "1px solid var(--gray-line)",
         marginBottom: "2rem"
       }}>
-        <h2>🛠️ Technology Evolution Journey</h2>
+        <h2>Technology Evolution Journey</h2>
         <div style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
@@ -365,10 +365,10 @@ const StatsIndex = (props) => {
         border: "1px solid var(--gray-line)",
         marginBottom: "2rem"
       }}>
-        <h2>🏷️ Most Written About Topics</h2>
+        <h2>Most Written About Topics</h2>
         <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>
           {topTags.map(([tag, count]) => (
-            <span key={tag} style={{
+            <Link key={tag} to={getTopicSlug(tag)} style={{
               background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
               color: "white",
               padding: "0.5rem 1rem",
@@ -377,7 +377,7 @@ const StatsIndex = (props) => {
               fontWeight: "500"
             }}>
               {tag} ({count})
-            </span>
+            </Link>
           ))}
         </div>
       </div>
@@ -390,18 +390,20 @@ const StatsIndex = (props) => {
           borderRadius: "12px",
           border: "1px solid var(--gray-line)"
         }}>
-          <h2>⭐ Featured Posts</h2>
+          <h2>Featured Posts</h2>
           <div style={{
             display: "grid",
             gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
             gap: "1rem"
           }}>
             {featuredPosts.map((post, index) => (
-              <div key={index} style={{
+              <Link key={index} to={post.slug} style={{
                 border: "1px solid var(--gray-line)",
                 borderRadius: "8px",
                 padding: "1.5rem",
-                background: "var(--background)"
+                background: "var(--background)",
+                color: "var(--text)",
+                textDecoration: "none"
               }}>
                 <h3 style={{ color: "var(--text)" }}>
                   {post.title}
@@ -413,7 +415,7 @@ const StatsIndex = (props) => {
                     day: 'numeric'
                   })}
                 </p>
-              </div>
+              </Link>
             ))}
           </div>
         </div>

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -12,10 +12,7 @@ const StatsIndex = (props) => {
           title
         }
       }
-      allMarkdownRemark(
-        sort: { frontmatter: { date: DESC } }
-        limit: 1000
-      ) {
+      allMarkdownRemark(sort: { frontmatter: { date: DESC } }, limit: 1000) {
         edges {
           node {
             frontmatter {
@@ -38,9 +35,9 @@ const StatsIndex = (props) => {
       }
     }
   `)
-  
+
   const { title } = data.site.siteMetadata
-  
+
   // Enhanced analytics
   const posts = data.allMarkdownRemark.edges
   const yearStats = {}
@@ -52,16 +49,16 @@ const StatsIndex = (props) => {
   let totalReadTime = 0
   const postLengths = []
   const writingStreak = {}
-  
+
   // Career milestones and themes
   const careerMilestones = {
     2013: "Started professional career at Changer",
     2015: "First blog about coding passion",
-    2018: "Leadership and architecture reflections", 
+    2018: "Leadership and architecture reflections",
     2019: "Infrastructure and tooling focus",
     2021: "Mentoring and growth themes emerge",
     2024: "Principal Engineer role, career transition",
-    2025: "Django CMS Fellow, 57 OSS PRs, ecosystem modernization"
+    2025: "Django CMS Fellow, 57 OSS PRs, ecosystem modernization",
   }
 
   const techEvolution = {
@@ -69,7 +66,7 @@ const StatsIndex = (props) => {
     "Growth Phase (2016-2018)": ["React", "DevOps", "Leadership"],
     "Expertise Era (2019-2021)": ["Go", "Infrastructure", "Mentoring"],
     "Principal Phase (2022-2024)": ["TypeScript", "Architecture", "Strategy"],
-    "Current (2025+)": ["Go Internals", "System Design", "AI Workflows"]
+    "Current (2025+)": ["Go Internals", "System Design", "AI Workflows"],
   }
 
   const interestingTrivia = [
@@ -82,7 +79,7 @@ const StatsIndex = (props) => {
     "📖 13-year journey from startup employee to Principal Engineer",
     "🎯 Influenced millions through multi-tenant CMS serving 3k+ websites",
     "💡 Contributed 57 PRs and reviewed 139 PRs in 2025 alone",
-    "🧠 Mentors developers and shapes open source ecosystem roadmap"
+    "🧠 Mentors developers and shapes open source ecosystem roadmap",
   ]
 
   posts.forEach(({ node }) => {
@@ -92,7 +89,7 @@ const StatsIndex = (props) => {
     const tags = node.frontmatter.tags || []
     const words = node.wordCount?.words || 0
     const readTime = node.timeToRead || 0
-    
+
     totalWords += words
     totalReadTime += readTime
     postLengths.push(words)
@@ -100,8 +97,8 @@ const StatsIndex = (props) => {
     if (date) {
       const dateObj = new Date(date)
       const year = dateObj.getFullYear()
-      const month = dateObj.toLocaleString('default', { month: 'long' })
-      
+      const month = dateObj.toLocaleString("default", { month: "long" })
+
       yearStats[year] = (yearStats[year] || 0) + 1
       monthStats[month] = (monthStats[month] || 0) + 1
       writingStreak[year] = (writingStreak[year] || []).concat(month)
@@ -109,7 +106,7 @@ const StatsIndex = (props) => {
 
     // Process tags
     if (Array.isArray(tags)) {
-      tags.forEach(tag => {
+      tags.forEach((tag) => {
         if (tag) {
           tagStats[tag] = (tagStats[tag] || 0) + 1
         }
@@ -120,23 +117,26 @@ const StatsIndex = (props) => {
       featuredPosts.push({
         title: node.frontmatter.title,
         date: date,
-        slug: node.fields.slug
+        slug: node.fields.slug,
       })
     }
   })
 
   const years = Object.keys(yearStats).sort((a, b) => b - a)
-  const mostActiveYear = Object.keys(yearStats).reduce((a, b) => yearStats[a] > yearStats[b] ? a : b)
+  const mostActiveYear = Object.keys(yearStats).reduce((a, b) =>
+    yearStats[a] > yearStats[b] ? a : b
+  )
   const avgWordsPerPost = Math.round(totalWords / totalPosts)
   const longestPost = Math.max(...postLengths)
   const shortestPost = Math.min(...postLengths)
-  
+
   const topTags = Object.entries(tagStats)
     .sort((a, b) => b[1] - a[1])
     .slice(0, 10)
 
-  const mostProductiveMonth = Object.entries(monthStats)
-    .sort((a, b) => b[1] - a[1])[0]
+  const mostProductiveMonth = Object.entries(monthStats).sort(
+    (a, b) => b[1] - a[1]
+  )[0]
 
   const writingPeriodYears = Math.max(...years) - Math.min(...years) + 1
   const avgPostsPerYear = Math.round(totalPosts / writingPeriodYears)
@@ -145,66 +145,93 @@ const StatsIndex = (props) => {
   return (
     <Layout location={props.location} title={title}>
       <Seo title="Blog Analytics & Insights" />
-      
+
       {/* Header */}
       <div style={{ marginBottom: "2rem" }}>
         <h1>Blog Analytics & Insights</h1>
-        <p style={{ fontSize: "1.1rem", color: "var(--text-muted)", margin: 0 }}>
-          A deep dive into {writingPeriodYears} years of writing, learning, and professional growth
+        <p
+          style={{ fontSize: "1.1rem", color: "var(--text-muted)", margin: 0 }}
+        >
+          A deep dive into {writingPeriodYears} years of writing, learning, and
+          professional growth
         </p>
       </div>
 
       {/* Quick Stats Grid */}
-      <div style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-        gap: "1rem",
-        marginBottom: "2rem"
-      }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+          gap: "1rem",
+          marginBottom: "2rem",
+        }}
+      >
         {[
           { label: "Total Posts", value: totalPosts },
           { label: "Total Words", value: totalWords.toLocaleString() },
           { label: "Reading Time", value: `${hoursOfContent}h` },
           { label: "Avg Words/Post", value: avgWordsPerPost },
           { label: "Writing Years", value: writingPeriodYears },
-          { label: "Posts/Year", value: avgPostsPerYear }
+          { label: "Posts/Year", value: avgPostsPerYear },
         ].map((stat, index) => (
-          <div key={index} style={{
-            background: "var(--background-card)",
-            padding: "1.5rem",
-            borderRadius: "8px",
-            border: "1px solid var(--gray-line)",
-            textAlign: "center",
-            boxShadow: "var(--shadow-card)"
-          }}>
-            <div style={{ fontSize: "1.5rem", fontWeight: "600", color: "var(--text)" }}>{stat.value}</div>
-            <div style={{ fontSize: "1rem", color: "var(--text-muted)" }}>{stat.label}</div>
+          <div
+            key={index}
+            style={{
+              background: "var(--background-card)",
+              padding: "1.5rem",
+              borderRadius: "8px",
+              border: "1px solid var(--gray-line)",
+              textAlign: "center",
+              boxShadow: "var(--shadow-card)",
+            }}
+          >
+            <div
+              style={{
+                fontSize: "1.5rem",
+                fontWeight: "600",
+                color: "var(--text)",
+              }}
+            >
+              {stat.value}
+            </div>
+            <div style={{ fontSize: "1rem", color: "var(--text-muted)" }}>
+              {stat.label}
+            </div>
           </div>
         ))}
       </div>
 
       {/* Career Journey */}
-      <div style={{
-        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-        borderRadius: "12px",
-        padding: "2rem",
-        marginBottom: "2rem",
-        color: "white"
-      }}>
+      <div
+        style={{
+          background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+          borderRadius: "12px",
+          padding: "2rem",
+          marginBottom: "2rem",
+          color: "white",
+        }}
+      >
         <h2 style={{ color: "white" }}>Career Evolution Through Writing</h2>
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
-          gap: "1rem"
-        }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
+            gap: "1rem",
+          }}
+        >
           {Object.entries(careerMilestones).map(([year, milestone]) => (
-            <div key={year} style={{
-              background: "rgba(255,255,255,0.1)",
-              borderRadius: "8px",
-              padding: "1rem",
-              backdropFilter: "blur(10px)"
-            }}>
-              <div style={{ fontWeight: "600", fontSize: "1.1rem" }}>{year}</div>
+            <div
+              key={year}
+              style={{
+                background: "rgba(255,255,255,0.1)",
+                borderRadius: "8px",
+                padding: "1rem",
+                backdropFilter: "blur(10px)",
+              }}
+            >
+              <div style={{ fontWeight: "600", fontSize: "1.1rem" }}>
+                {year}
+              </div>
               <div style={{ fontSize: "1rem", opacity: 0.9 }}>{milestone}</div>
             </div>
           ))}
@@ -212,28 +239,35 @@ const StatsIndex = (props) => {
       </div>
 
       {/* Interesting Trivia */}
-      <div style={{
-        background: "var(--gray-bg)",
-        borderRadius: "12px",
-        padding: "2rem",
-        marginBottom: "2rem",
-        border: "1px solid var(--gray-line)"
-      }}>
+      <div
+        style={{
+          background: "var(--gray-bg)",
+          borderRadius: "12px",
+          padding: "2rem",
+          marginBottom: "2rem",
+          border: "1px solid var(--gray-line)",
+        }}
+      >
         <h2>Interesting Trivia</h2>
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-          gap: "1rem"
-        }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+            gap: "1rem",
+          }}
+        >
           {interestingTrivia.map((trivia, index) => (
-            <div key={index} style={{
-              background: "var(--background-card)",
-              padding: "1rem",
-              borderRadius: "8px",
-              border: "1px solid var(--gray-line)",
-              fontSize: "1.1rem",
-              color: "var(--text)"
-            }}>
+            <div
+              key={index}
+              style={{
+                background: "var(--background-card)",
+                padding: "1rem",
+                borderRadius: "8px",
+                border: "1px solid var(--gray-line)",
+                fontSize: "1.1rem",
+                color: "var(--text)",
+              }}
+            >
               {trivia}
             </div>
           ))}
@@ -241,44 +275,76 @@ const StatsIndex = (props) => {
       </div>
 
       {/* Writing Patterns */}
-      <div style={{ 
-        marginBottom: "2rem",
-        display: "grid",
-        gridTemplateColumns: "2fr 1fr",
-        gap: "2rem"
-      }}>
+      <div
+        style={{
+          marginBottom: "2rem",
+          display: "grid",
+          gridTemplateColumns: "2fr 1fr",
+          gap: "2rem",
+        }}
+      >
         {/* Posts by Year */}
-        <div style={{
-          background: "var(--background-card)",
-          padding: "2rem",
-          borderRadius: "12px",
-          border: "1px solid var(--gray-line)"
-        }}>
+        <div
+          style={{
+            background: "var(--background-card)",
+            padding: "2rem",
+            borderRadius: "12px",
+            border: "1px solid var(--gray-line)",
+          }}
+        >
           <h2>Posts by Year</h2>
-          <div style={{ fontFamily: "monospace", fontSize: "14px", lineHeight: "1.8", color: "var(--text)" }}>
-            {years.map(year => {
+          <div
+            style={{
+              fontFamily: "monospace",
+              fontSize: "14px",
+              lineHeight: "1.8",
+              color: "var(--text)",
+            }}
+          >
+            {years.map((year) => {
               const count = yearStats[year]
-              const barLength = Math.round((count / Math.max(...Object.values(yearStats))) * 25)
+              const barLength = Math.round(
+                (count / Math.max(...Object.values(yearStats))) * 25
+              )
               const bar = "█".repeat(barLength)
               const milestone = careerMilestones[year]
               return (
                 <div key={year} style={{ marginBottom: "8px" }}>
                   <div style={{ display: "flex", alignItems: "center" }}>
-                    <span style={{ width: "60px", textAlign: "right", marginRight: "15px", fontWeight: "600", color: "var(--text)" }}>
+                    <span
+                      style={{
+                        width: "60px",
+                        textAlign: "right",
+                        marginRight: "15px",
+                        fontWeight: "600",
+                        color: "var(--text)",
+                      }}
+                    >
                       {year}
                     </span>
-                    <span style={{ width: "40px", textAlign: "right", marginRight: "15px", color: "var(--text)" }}>
+                    <span
+                      style={{
+                        width: "40px",
+                        textAlign: "right",
+                        marginRight: "15px",
+                        color: "var(--text)",
+                      }}
+                    >
                       {count}
                     </span>
-                    <span style={{ color: "var(--blue)", marginRight: "10px" }}>{bar}</span>
+                    <span style={{ color: "var(--blue)", marginRight: "10px" }}>
+                      {bar}
+                    </span>
                   </div>
                   {milestone && (
-                    <div style={{ 
-                      fontSize: "14px", 
-                      color: "var(--text-muted)", 
-                      marginLeft: "115px",
-                      fontStyle: "italic"
-                    }}>
+                    <div
+                      style={{
+                        fontSize: "14px",
+                        color: "var(--text-muted)",
+                        marginLeft: "115px",
+                        fontStyle: "italic",
+                      }}
+                    >
                       {milestone}
                     </div>
                   )}
@@ -289,28 +355,40 @@ const StatsIndex = (props) => {
         </div>
 
         {/* Quick Insights */}
-        <div style={{
-          background: "var(--background-card)",
-          padding: "2rem",
-          borderRadius: "12px",
-          border: "1px solid var(--gray-line)"
-        }}>
+        <div
+          style={{
+            background: "var(--background-card)",
+            padding: "2rem",
+            borderRadius: "12px",
+            border: "1px solid var(--gray-line)",
+          }}
+        >
           <h2>Quick Insights</h2>
-          <div style={{ fontSize: "1rem", lineHeight: "1.6", color: "var(--text)" }}>
+          <div
+            style={{
+              fontSize: "1rem",
+              lineHeight: "1.6",
+              color: "var(--text)",
+            }}
+          >
             <div style={{ marginBottom: "1rem" }}>
-              <strong>Most Active:</strong><br/>
+              <strong>Most Active:</strong>
+              <br />
               {mostActiveYear} ({yearStats[mostActiveYear]} posts)
             </div>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>Productive Month:</strong><br/>
+              <strong>Productive Month:</strong>
+              <br />
               {mostProductiveMonth?.[0]} ({mostProductiveMonth?.[1]} posts)
             </div>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>Post Lengths:</strong><br/>
+              <strong>Post Lengths:</strong>
+              <br />
               {shortestPost} - {longestPost} words
             </div>
             <div style={{ marginBottom: "1rem" }}>
-              <strong>Total Reading:</strong><br/>
+              <strong>Total Reading:</strong>
+              <br />
               {hoursOfContent} hours of content
             </div>
           </div>
@@ -318,36 +396,46 @@ const StatsIndex = (props) => {
       </div>
 
       {/* Technology Evolution */}
-      <div style={{
-        background: "var(--background-card)",
-        padding: "2rem",
-        borderRadius: "12px",
-        border: "1px solid var(--gray-line)",
-        marginBottom: "2rem"
-      }}>
+      <div
+        style={{
+          background: "var(--background-card)",
+          padding: "2rem",
+          borderRadius: "12px",
+          border: "1px solid var(--gray-line)",
+          marginBottom: "2rem",
+        }}
+      >
         <h2>Technology Evolution Journey</h2>
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
-          gap: "1.5rem"
-        }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
+            gap: "1.5rem",
+          }}
+        >
           {Object.entries(techEvolution).map(([period, techs]) => (
-            <div key={period} style={{
-              border: "1px solid var(--gray-line)",
-              borderRadius: "8px",
-              padding: "1.5rem",
-              backgroundColor: "var(--background)"
-            }}>
+            <div
+              key={period}
+              style={{
+                border: "1px solid var(--gray-line)",
+                borderRadius: "8px",
+                padding: "1.5rem",
+                backgroundColor: "var(--background)",
+              }}
+            >
               <h3 style={{ color: "var(--text)" }}>{period}</h3>
               <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
-                {techs.map(tech => (
-                  <span key={tech} style={{
-                    background: "var(--gray-100)",
-                    padding: "0.25rem 0.75rem",
-                    borderRadius: "20px",
-                    fontSize: "0.8rem",
-                    color: "var(--text)"
-                  }}>
+                {techs.map((tech) => (
+                  <span
+                    key={tech}
+                    style={{
+                      background: "var(--gray-100)",
+                      padding: "0.25rem 0.75rem",
+                      borderRadius: "20px",
+                      fontSize: "0.8rem",
+                      color: "var(--text)",
+                    }}
+                  >
                     {tech}
                   </span>
                 ))}
@@ -358,24 +446,30 @@ const StatsIndex = (props) => {
       </div>
 
       {/* Top Tags */}
-      <div style={{
-        background: "var(--background-card)",
-        padding: "2rem",
-        borderRadius: "12px",
-        border: "1px solid var(--gray-line)",
-        marginBottom: "2rem"
-      }}>
+      <div
+        style={{
+          background: "var(--background-card)",
+          padding: "2rem",
+          borderRadius: "12px",
+          border: "1px solid var(--gray-line)",
+          marginBottom: "2rem",
+        }}
+      >
         <h2>Most Written About Topics</h2>
         <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>
           {topTags.map(([tag, count]) => (
-            <Link key={tag} to={getTopicSlug(tag)} style={{
-              background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-              color: "white",
-              padding: "0.5rem 1rem",
-              borderRadius: "25px",
-              fontSize: "0.9rem",
-              fontWeight: "500"
-            }}>
+            <Link
+              key={tag}
+              to={getTopicSlug(tag)}
+              style={{
+                background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+                color: "white",
+                padding: "0.5rem 1rem",
+                borderRadius: "25px",
+                fontSize: "0.9rem",
+                fontWeight: "500",
+              }}
+            >
               {tag} ({count})
             </Link>
           ))}
@@ -384,35 +478,47 @@ const StatsIndex = (props) => {
 
       {/* Featured Posts */}
       {featuredPosts.length > 0 && (
-        <div style={{
-          background: "var(--background-card)",
-          padding: "2rem",
-          borderRadius: "12px",
-          border: "1px solid var(--gray-line)"
-        }}>
+        <div
+          style={{
+            background: "var(--background-card)",
+            padding: "2rem",
+            borderRadius: "12px",
+            border: "1px solid var(--gray-line)",
+          }}
+        >
           <h2>Featured Posts</h2>
-          <div style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-            gap: "1rem"
-          }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
+              gap: "1rem",
+            }}
+          >
             {featuredPosts.map((post, index) => (
-              <Link key={index} to={post.slug} style={{
-                border: "1px solid var(--gray-line)",
-                borderRadius: "8px",
-                padding: "1.5rem",
-                background: "var(--background)",
-                color: "var(--text)",
-                textDecoration: "none"
-              }}>
-                <h3 style={{ color: "var(--text)" }}>
-                  {post.title}
-                </h3>
-                <p style={{ fontSize: "0.9rem", color: "var(--text-muted)", margin: 0 }}>
-                  {new Date(post.date).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
+              <Link
+                key={index}
+                to={post.slug}
+                style={{
+                  border: "1px solid var(--gray-line)",
+                  borderRadius: "8px",
+                  padding: "1.5rem",
+                  background: "var(--background)",
+                  color: "var(--text)",
+                  textDecoration: "none",
+                }}
+              >
+                <h3 style={{ color: "var(--text)" }}>{post.title}</h3>
+                <p
+                  style={{
+                    fontSize: "0.9rem",
+                    color: "var(--text-muted)",
+                    margin: 0,
+                  }}
+                >
+                  {new Date(post.date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
                   })}
                 </p>
               </Link>

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -1,8 +1,26 @@
 import React from "react"
 import { Link, useStaticQuery, graphql } from "gatsby"
+
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import { getTopicSlug } from "../utils/content"
+import { getPostTitle, getTopicSlug } from "../utils/content"
+
+const formatNumber = (value) => value.toLocaleString("en-US")
+
+const formatDate = (date) =>
+  new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+
+const getEra = (year) => {
+  if (year <= 2015) return "Early Craft"
+  if (year <= 2018) return "Full-Stack Growth"
+  if (year <= 2021) return "Systems & Leadership"
+  if (year <= 2024) return "Principal Engineer"
+  return "Open Source & AI"
+}
 
 const StatsIndex = (props) => {
   const data = useStaticQuery(graphql`
@@ -24,6 +42,7 @@ const StatsIndex = (props) => {
             }
             fields {
               slug
+              collection
             }
             excerpt
             wordCount {
@@ -37,495 +56,241 @@ const StatsIndex = (props) => {
   `)
 
   const { title } = data.site.siteMetadata
+  const posts = data.allMarkdownRemark.edges.map(({ node }) => node)
+  const blogPosts = posts.filter((post) => post.fields.collection !== "til")
+  const tilPosts = posts.filter((post) => post.fields.collection === "til")
 
-  // Enhanced analytics
-  const posts = data.allMarkdownRemark.edges
-  const yearStats = {}
-  const monthStats = {}
-  const tagStats = {}
-  const featuredPosts = []
-  let totalPosts = 0
-  let totalWords = 0
-  let totalReadTime = 0
-  const postLengths = []
-  const writingStreak = {}
-
-  // Career milestones and themes
-  const careerMilestones = {
-    2013: "Started professional career at Changer",
-    2015: "First blog about coding passion",
-    2018: "Leadership and architecture reflections",
-    2019: "Infrastructure and tooling focus",
-    2021: "Mentoring and growth themes emerge",
-    2024: "Principal Engineer role, career transition",
-    2025: "Django CMS Fellow, 57 OSS PRs, ecosystem modernization",
-  }
-
-  const techEvolution = {
-    "Early Years (2013-2015)": ["JavaScript", "Python", "Django"],
-    "Growth Phase (2016-2018)": ["React", "DevOps", "Leadership"],
-    "Expertise Era (2019-2021)": ["Go", "Infrastructure", "Mentoring"],
-    "Principal Phase (2022-2024)": ["TypeScript", "Architecture", "Strategy"],
-    "Current (2025+)": ["Go Internals", "System Design", "AI Workflows"],
-  }
-
-  const interestingTrivia = [
-    "🚀 Started coding at age 10 with IBM PC and LOGO",
-    "🎸 Learned guitar alongside his kid in 2024",
-    "🚶‍♂️ Walks 5-6km daily as part of work-life balance",
-    "📚 From college affordability to music lessons — full circle",
-    "🔧 Advocates for minimalist tooling — Vim over bloated IDEs",
-    "🌍 Has worked across 3+ time zones seamlessly",
-    "📖 13-year journey from startup employee to Principal Engineer",
-    "🎯 Influenced millions through multi-tenant CMS serving 3k+ websites",
-    "💡 Contributed 57 PRs and reviewed 139 PRs in 2025 alone",
-    "🧠 Mentors developers and shapes open source ecosystem roadmap",
-  ]
-
-  posts.forEach(({ node }) => {
-    totalPosts++
-    const date = node.frontmatter.date
-    const featured = node.frontmatter.featured
-    const tags = node.frontmatter.tags || []
-    const words = node.wordCount?.words || 0
-    const readTime = node.timeToRead || 0
-
-    totalWords += words
-    totalReadTime += readTime
-    postLengths.push(words)
-
-    if (date) {
-      const dateObj = new Date(date)
-      const year = dateObj.getFullYear()
-      const month = dateObj.toLocaleString("default", { month: "long" })
-
-      yearStats[year] = (yearStats[year] || 0) + 1
-      monthStats[month] = (monthStats[month] || 0) + 1
-      writingStreak[year] = (writingStreak[year] || []).concat(month)
-    }
-
-    // Process tags
-    if (Array.isArray(tags)) {
-      tags.forEach((tag) => {
-        if (tag) {
-          tagStats[tag] = (tagStats[tag] || 0) + 1
-        }
-      })
-    }
-
-    if (featured) {
-      featuredPosts.push({
-        title: node.frontmatter.title,
-        date: date,
-        slug: node.fields.slug,
-      })
-    }
-  })
-
-  const years = Object.keys(yearStats).sort((a, b) => b - a)
-  const mostActiveYear = Object.keys(yearStats).reduce((a, b) =>
-    yearStats[a] > yearStats[b] ? a : b
+  const totals = posts.reduce(
+    (acc, post) => {
+      const words = post.wordCount?.words || 0
+      acc.words += words
+      acc.readTime += post.timeToRead || 0
+      if (post.frontmatter.featured) acc.featured += 1
+      return acc
+    },
+    { words: 0, readTime: 0, featured: 0 }
   )
-  const avgWordsPerPost = Math.round(totalWords / totalPosts)
-  const longestPost = Math.max(...postLengths)
-  const shortestPost = Math.min(...postLengths)
 
-  const topTags = Object.entries(tagStats)
+  const postsByYear = posts.reduce((acc, post) => {
+    if (!post.frontmatter.date) return acc
+    const year = new Date(post.frontmatter.date).getFullYear()
+    acc[year] = (acc[year] || 0) + 1
+    return acc
+  }, {})
+
+  const tagCounts = posts.reduce((acc, post) => {
+    ;(post.frontmatter.tags || []).forEach((tag) => {
+      acc[tag] = (acc[tag] || 0) + 1
+    })
+    return acc
+  }, {})
+
+  const sortedYears = Object.entries(postsByYear)
+    .map(([year, count]) => ({
+      year: Number(year),
+      count,
+      era: getEra(Number(year)),
+    }))
+    .sort((a, b) => a.year - b.year)
+
+  const maxYearCount = Math.max(...sortedYears.map((entry) => entry.count))
+  const startYear = sortedYears[0]?.year
+  const endYear = sortedYears[sortedYears.length - 1]?.year
+  const writingYears = startYear && endYear ? endYear - startYear + 1 : 0
+
+  const topTopics = Object.entries(tagCounts)
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 10)
+    .slice(0, 12)
 
-  const mostProductiveMonth = Object.entries(monthStats).sort(
-    (a, b) => b[1] - a[1]
-  )[0]
+  const longestPosts = [...blogPosts]
+    .sort((a, b) => (b.wordCount?.words || 0) - (a.wordCount?.words || 0))
+    .slice(0, 5)
 
-  const writingPeriodYears = Math.max(...years) - Math.min(...years) + 1
-  const avgPostsPerYear = Math.round(totalPosts / writingPeriodYears)
-  const hoursOfContent = Math.round(totalReadTime / 60)
+  const featuredPosts = blogPosts
+    .filter((post) => post.frontmatter.featured)
+    .slice(0, 6)
+
+  const mostActiveYear = [...sortedYears].sort((a, b) => b.count - a.count)[0]
+  const avgWordsPerPost = Math.round(totals.words / posts.length)
+  const avgReadTime = Math.round(totals.readTime / posts.length)
+  const readingHours = Math.round(totals.readTime / 60)
+
+  const metrics = [
+    { label: "Published pieces", value: formatNumber(posts.length) },
+    { label: "Essays", value: formatNumber(blogPosts.length) },
+    { label: "TIL notes", value: formatNumber(tilPosts.length) },
+    { label: "Total words", value: formatNumber(totals.words) },
+    { label: "Reading hours", value: `${readingHours}h` },
+    { label: "Featured posts", value: formatNumber(totals.featured) },
+  ]
 
   return (
     <Layout location={props.location} title={title}>
-      <Seo title="Blog Analytics & Insights" />
+      <Seo
+        title="Writing Stats"
+        description="A data view of Vinit Kumar's essays, technical notes, topics, writing history, and featured posts."
+        pathname={props.location.pathname}
+      />
 
-      {/* Header */}
-      <div style={{ marginBottom: "2rem" }}>
-        <h1>Blog Analytics & Insights</h1>
-        <p
-          style={{ fontSize: "1.1rem", color: "var(--text-muted)", margin: 0 }}
-        >
-          A deep dive into {writingPeriodYears} years of writing, learning, and
-          professional growth
-        </p>
-      </div>
+      <div className="stats-page">
+        <header className="stats-hero">
+          <p className="eyebrow">Writing Stats</p>
+          <h1>The archive as a map of long-running technical taste.</h1>
+          <p>
+            A quantitative view of the site: publishing cadence, topic weight,
+            long-form depth, and the themes that keep showing up over time.
+          </p>
+        </header>
 
-      {/* Quick Stats Grid */}
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-          gap: "1rem",
-          marginBottom: "2rem",
-        }}
-      >
-        {[
-          { label: "Total Posts", value: totalPosts },
-          { label: "Total Words", value: totalWords.toLocaleString() },
-          { label: "Reading Time", value: `${hoursOfContent}h` },
-          { label: "Avg Words/Post", value: avgWordsPerPost },
-          { label: "Writing Years", value: writingPeriodYears },
-          { label: "Posts/Year", value: avgPostsPerYear },
-        ].map((stat, index) => (
-          <div
-            key={index}
-            style={{
-              background: "var(--background-card)",
-              padding: "1.5rem",
-              borderRadius: "8px",
-              border: "1px solid var(--gray-line)",
-              textAlign: "center",
-              boxShadow: "var(--shadow-card)",
-            }}
-          >
-            <div
-              style={{
-                fontSize: "1.5rem",
-                fontWeight: "600",
-                color: "var(--text)",
-              }}
-            >
-              {stat.value}
+        <section className="stats-metrics" aria-label="Writing summary">
+          {metrics.map((metric) => (
+            <div key={metric.label}>
+              <strong>{metric.value}</strong>
+              <span>{metric.label}</span>
             </div>
-            <div style={{ fontSize: "1rem", color: "var(--text-muted)" }}>
-              {stat.label}
-            </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </section>
 
-      {/* Career Journey */}
-      <div
-        style={{
-          background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-          borderRadius: "12px",
-          padding: "2rem",
-          marginBottom: "2rem",
-          color: "white",
-        }}
-      >
-        <h2 style={{ color: "white" }}>Career Evolution Through Writing</h2>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
-            gap: "1rem",
-          }}
-        >
-          {Object.entries(careerMilestones).map(([year, milestone]) => (
-            <div
-              key={year}
-              style={{
-                background: "rgba(255,255,255,0.1)",
-                borderRadius: "8px",
-                padding: "1rem",
-                backdropFilter: "blur(10px)",
-              }}
-            >
-              <div style={{ fontWeight: "600", fontSize: "1.1rem" }}>
-                {year}
+        <section className="stats-split">
+          <div className="stats-panel stats-panel-large">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Cadence</p>
+                <h2>Posts by year</h2>
               </div>
-              <div style={{ fontSize: "1rem", opacity: 0.9 }}>{milestone}</div>
+              <span className="stats-note">
+                {writingYears} years · peak {mostActiveYear?.year}
+              </span>
             </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Interesting Trivia */}
-      <div
-        style={{
-          background: "var(--gray-bg)",
-          borderRadius: "12px",
-          padding: "2rem",
-          marginBottom: "2rem",
-          border: "1px solid var(--gray-line)",
-        }}
-      >
-        <h2>Interesting Trivia</h2>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-            gap: "1rem",
-          }}
-        >
-          {interestingTrivia.map((trivia, index) => (
-            <div
-              key={index}
-              style={{
-                background: "var(--background-card)",
-                padding: "1rem",
-                borderRadius: "8px",
-                border: "1px solid var(--gray-line)",
-                fontSize: "1.1rem",
-                color: "var(--text)",
-              }}
-            >
-              {trivia}
-            </div>
-          ))}
-        </div>
-      </div>
-
-      {/* Writing Patterns */}
-      <div
-        style={{
-          marginBottom: "2rem",
-          display: "grid",
-          gridTemplateColumns: "2fr 1fr",
-          gap: "2rem",
-        }}
-      >
-        {/* Posts by Year */}
-        <div
-          style={{
-            background: "var(--background-card)",
-            padding: "2rem",
-            borderRadius: "12px",
-            border: "1px solid var(--gray-line)",
-          }}
-        >
-          <h2>Posts by Year</h2>
-          <div
-            style={{
-              fontFamily: "monospace",
-              fontSize: "14px",
-              lineHeight: "1.8",
-              color: "var(--text)",
-            }}
-          >
-            {years.map((year) => {
-              const count = yearStats[year]
-              const barLength = Math.round(
-                (count / Math.max(...Object.values(yearStats))) * 25
-              )
-              const bar = "█".repeat(barLength)
-              const milestone = careerMilestones[year]
-              return (
-                <div key={year} style={{ marginBottom: "8px" }}>
-                  <div style={{ display: "flex", alignItems: "center" }}>
-                    <span
-                      style={{
-                        width: "60px",
-                        textAlign: "right",
-                        marginRight: "15px",
-                        fontWeight: "600",
-                        color: "var(--text)",
-                      }}
-                    >
-                      {year}
-                    </span>
-                    <span
-                      style={{
-                        width: "40px",
-                        textAlign: "right",
-                        marginRight: "15px",
-                        color: "var(--text)",
-                      }}
-                    >
-                      {count}
-                    </span>
-                    <span style={{ color: "var(--blue)", marginRight: "10px" }}>
-                      {bar}
-                    </span>
-                  </div>
-                  {milestone && (
+            <div className="year-bars">
+              {sortedYears.map((entry) => (
+                <div className="year-bar-row" key={entry.year}>
+                  <span>{entry.year}</span>
+                  <div className="year-bar-track">
                     <div
+                      className="year-bar-fill"
                       style={{
-                        fontSize: "14px",
-                        color: "var(--text-muted)",
-                        marginLeft: "115px",
-                        fontStyle: "italic",
+                        width: `${(entry.count / maxYearCount) * 100}%`,
                       }}
-                    >
-                      {milestone}
-                    </div>
-                  )}
+                    />
+                  </div>
+                  <strong>{entry.count}</strong>
                 </div>
-              )
-            })}
-          </div>
-        </div>
-
-        {/* Quick Insights */}
-        <div
-          style={{
-            background: "var(--background-card)",
-            padding: "2rem",
-            borderRadius: "12px",
-            border: "1px solid var(--gray-line)",
-          }}
-        >
-          <h2>Quick Insights</h2>
-          <div
-            style={{
-              fontSize: "1rem",
-              lineHeight: "1.6",
-              color: "var(--text)",
-            }}
-          >
-            <div style={{ marginBottom: "1rem" }}>
-              <strong>Most Active:</strong>
-              <br />
-              {mostActiveYear} ({yearStats[mostActiveYear]} posts)
-            </div>
-            <div style={{ marginBottom: "1rem" }}>
-              <strong>Productive Month:</strong>
-              <br />
-              {mostProductiveMonth?.[0]} ({mostProductiveMonth?.[1]} posts)
-            </div>
-            <div style={{ marginBottom: "1rem" }}>
-              <strong>Post Lengths:</strong>
-              <br />
-              {shortestPost} - {longestPost} words
-            </div>
-            <div style={{ marginBottom: "1rem" }}>
-              <strong>Total Reading:</strong>
-              <br />
-              {hoursOfContent} hours of content
+              ))}
             </div>
           </div>
-        </div>
-      </div>
 
-      {/* Technology Evolution */}
-      <div
-        style={{
-          background: "var(--background-card)",
-          padding: "2rem",
-          borderRadius: "12px",
-          border: "1px solid var(--gray-line)",
-          marginBottom: "2rem",
-        }}
-      >
-        <h2>Technology Evolution Journey</h2>
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
-            gap: "1.5rem",
-          }}
-        >
-          {Object.entries(techEvolution).map(([period, techs]) => (
-            <div
-              key={period}
-              style={{
-                border: "1px solid var(--gray-line)",
-                borderRadius: "8px",
-                padding: "1.5rem",
-                backgroundColor: "var(--background)",
-              }}
-            >
-              <h3 style={{ color: "var(--text)" }}>{period}</h3>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
-                {techs.map((tech) => (
-                  <span
-                    key={tech}
-                    style={{
-                      background: "var(--gray-100)",
-                      padding: "0.25rem 0.75rem",
-                      borderRadius: "20px",
-                      fontSize: "0.8rem",
-                      color: "var(--text)",
-                    }}
-                  >
-                    {tech}
-                  </span>
-                ))}
+          <aside className="stats-panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Quick Read</p>
+                <h2>Signals</h2>
               </div>
             </div>
-          ))}
-        </div>
-      </div>
+            <dl className="stats-facts">
+              <div>
+                <dt>Most active year</dt>
+                <dd>
+                  {mostActiveYear?.year} with {mostActiveYear?.count} posts
+                </dd>
+              </div>
+              <div>
+                <dt>Average length</dt>
+                <dd>{formatNumber(avgWordsPerPost)} words per piece</dd>
+              </div>
+              <div>
+                <dt>Average read</dt>
+                <dd>{avgReadTime} minutes</dd>
+              </div>
+              <div>
+                <dt>Current era</dt>
+                <dd>{getEra(endYear)}</dd>
+              </div>
+            </dl>
+          </aside>
+        </section>
 
-      {/* Top Tags */}
-      <div
-        style={{
-          background: "var(--background-card)",
-          padding: "2rem",
-          borderRadius: "12px",
-          border: "1px solid var(--gray-line)",
-          marginBottom: "2rem",
-        }}
-      >
-        <h2>Most Written About Topics</h2>
-        <div style={{ display: "flex", flexWrap: "wrap", gap: "0.75rem" }}>
-          {topTags.map(([tag, count]) => (
-            <Link
-              key={tag}
-              to={getTopicSlug(tag)}
-              style={{
-                background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
-                color: "white",
-                padding: "0.5rem 1rem",
-                borderRadius: "25px",
-                fontSize: "0.9rem",
-                fontWeight: "500",
-              }}
-            >
-              {tag} ({count})
-            </Link>
-          ))}
-        </div>
-      </div>
-
-      {/* Featured Posts */}
-      {featuredPosts.length > 0 && (
-        <div
-          style={{
-            background: "var(--background-card)",
-            padding: "2rem",
-            borderRadius: "12px",
-            border: "1px solid var(--gray-line)",
-          }}
-        >
-          <h2>Featured Posts</h2>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(300px, 1fr))",
-              gap: "1rem",
-            }}
-          >
-            {featuredPosts.map((post, index) => (
-              <Link
-                key={index}
-                to={post.slug}
-                style={{
-                  border: "1px solid var(--gray-line)",
-                  borderRadius: "8px",
-                  padding: "1.5rem",
-                  background: "var(--background)",
-                  color: "var(--text)",
-                  textDecoration: "none",
-                }}
-              >
-                <h3 style={{ color: "var(--text)" }}>{post.title}</h3>
-                <p
-                  style={{
-                    fontSize: "0.9rem",
-                    color: "var(--text-muted)",
-                    margin: 0,
-                  }}
-                >
-                  {new Date(post.date).toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })}
-                </p>
+        <section className="stats-panel">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Themes</p>
+              <h2>Most written about topics</h2>
+            </div>
+          </div>
+          <div className="topic-cloud stats-topic-cloud">
+            {topTopics.map(([tag, count]) => (
+              <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
+                {tag}
+                <span>{count}</span>
               </Link>
             ))}
           </div>
-        </div>
-      )}
+        </section>
+
+        <section className="stats-panel">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Timeline</p>
+              <h2>Writing eras</h2>
+            </div>
+          </div>
+          <div className="era-grid">
+            {sortedYears.map((entry) => (
+              <div className="era-card" key={entry.year}>
+                <span>{entry.year}</span>
+                <strong>{entry.era}</strong>
+                <p>
+                  {entry.count} post{entry.count === 1 ? "" : "s"}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="stats-split">
+          <div className="stats-panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Depth</p>
+                <h2>Longest essays</h2>
+              </div>
+            </div>
+            <div className="compact-post-list">
+              {longestPosts.map((post) => (
+                <Link
+                  key={post.fields.slug}
+                  to={post.fields.slug}
+                  className="compact-post-link"
+                >
+                  <span>{formatNumber(post.wordCount?.words || 0)} words</span>
+                  <strong>{getPostTitle(post)}</strong>
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="stats-panel">
+            <div className="section-heading">
+              <div>
+                <p className="eyebrow">Start Here</p>
+                <h2>Featured posts</h2>
+              </div>
+            </div>
+            <div className="compact-post-list">
+              {featuredPosts.map((post) => (
+                <Link
+                  key={post.fields.slug}
+                  to={post.fields.slug}
+                  className="compact-post-link"
+                >
+                  <span>{formatDate(post.frontmatter.date)}</span>
+                  <strong>{getPostTitle(post)}</strong>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      </div>
     </Layout>
   )
 }

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -126,12 +126,6 @@ const StatsIndex = (props) => {
 
   return (
     <Layout location={props.location} title={title}>
-      <Seo
-        title="Writing Stats"
-        description="A data view of Vinit Kumar's essays, technical notes, topics, writing history, and featured posts."
-        pathname={props.location.pathname}
-      />
-
       <div className="stats-page">
         <header className="stats-hero">
           <p className="eyebrow">Writing Stats</p>
@@ -296,3 +290,11 @@ const StatsIndex = (props) => {
 }
 
 export default StatsIndex
+
+export const Head = ({ location }) => (
+  <Seo
+    title="Writing Stats"
+    description="A data view of Vinit Kumar's essays, technical notes, topics, writing history, and featured posts."
+    pathname={location.pathname}
+  />
+)

--- a/src/pages/til.js
+++ b/src/pages/til.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
@@ -18,21 +17,14 @@ const TilIndex = ({ data, location }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Helmet>
-        <meta
-          name="description"
-          content="Today I Learned - Short notes on programming, technology, and development insights"
-        />
-      </Helmet>
-      <Seo title="Today I Learned" />
-
       {/* Header */}
       <header
         style={{
           marginBottom: rhythm(2),
           textAlign: "center",
           padding: rhythm(2),
-          background: "linear-gradient(135deg, var(--nav-til) 0%, #d97706 100%)",
+          background:
+            "linear-gradient(135deg, var(--nav-til) 0%, #d97706 100%)",
           borderRadius: "var(--radius)",
           color: "white",
         }}
@@ -57,8 +49,8 @@ const TilIndex = ({ data, location }) => {
             marginRight: "auto",
           }}
         >
-          Short notes on programming, technology, and development insights. Quick
-          reads that pack valuable knowledge.
+          Short notes on programming, technology, and development insights.
+          Quick reads that pack valuable knowledge.
         </p>
       </header>
 
@@ -300,6 +292,14 @@ const TilIndex = ({ data, location }) => {
 }
 
 export default TilIndex
+
+export const Head = ({ location }) => (
+  <Seo
+    title="Today I Learned"
+    description="Today I Learned - Short notes on programming, technology, and development insights"
+    pathname={location.pathname}
+  />
+)
 
 export const pageQuery = graphql`
   query {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1269,6 +1269,190 @@ h6 {
 }
 
 /* ===========================================
+   Stats Page
+   =========================================== */
+.stats-page {
+  max-width: 72rem;
+  margin: 0 auto;
+}
+
+.stats-hero {
+  border-bottom: 1px solid var(--gray-line);
+  margin: 1.5rem 0;
+  max-width: 58rem;
+  padding-bottom: 1.5rem;
+}
+
+.stats-hero h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.05;
+  max-width: 14ch;
+  margin-bottom: 1rem;
+}
+
+.stats-hero p:not(.eyebrow) {
+  color: var(--text-muted);
+  font-size: 1.15rem;
+  max-width: 47rem;
+}
+
+.stats-metrics {
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  margin-bottom: 2rem;
+  overflow: hidden;
+}
+
+.stats-metrics div {
+  background: var(--background-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  justify-content: end;
+  min-height: 8rem;
+  padding: 1rem;
+}
+
+.stats-metrics strong {
+  font-family: var(--font-family-heading);
+  font-size: clamp(1.45rem, 3vw, 2.6rem);
+  line-height: 1;
+}
+
+.stats-metrics span,
+.stats-note {
+  color: var(--text-muted);
+  font-family: var(--font-family-heading);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.stats-split {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.65fr);
+  margin-top: 1rem;
+}
+
+.stats-panel {
+  background: var(--background-card);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  padding: 1rem;
+}
+
+.stats-panel-large {
+  min-height: 28rem;
+}
+
+.year-bars {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.year-bar-row {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 4rem minmax(0, 1fr) 2.5rem;
+}
+
+.year-bar-row span,
+.year-bar-row strong {
+  font-family: var(--font-family-heading);
+  font-size: 0.9rem;
+}
+
+.year-bar-row span {
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+.year-bar-row strong {
+  text-align: right;
+}
+
+.year-bar-track {
+  background: var(--gray-100);
+  border-radius: 999px;
+  height: 0.7rem;
+  overflow: hidden;
+}
+
+.year-bar-fill {
+  background: var(--link-color);
+  border-radius: inherit;
+  height: 100%;
+  min-width: 0.35rem;
+}
+
+.stats-facts {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+}
+
+.stats-facts div {
+  border-top: 1px solid var(--gray-line);
+  padding-top: 0.85rem;
+}
+
+.stats-facts dt {
+  color: var(--text-muted);
+  font-family: var(--font-family-heading);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.stats-facts dd {
+  margin: 0.25rem 0 0;
+}
+
+.stats-topic-cloud {
+  margin-top: 0.5rem;
+}
+
+.era-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+}
+
+.era-card {
+  background: var(--gray-bg);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  min-height: 8rem;
+  padding: 0.9rem;
+}
+
+.era-card span {
+  color: var(--text-muted);
+  display: block;
+  font-family: var(--font-family-heading);
+  font-size: 0.82rem;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+}
+
+.era-card strong {
+  display: block;
+  font-family: var(--font-family-heading);
+  line-height: 1.25;
+}
+
+.era-card p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin: 0.5rem 0 0;
+}
+
+/* ===========================================
    Search Component
    =========================================== */
 .search-container {
@@ -1812,12 +1996,22 @@ h6 {
   .recommendation-metrics,
   .recommendation-theme-grid,
   .recommendation-spotlight-grid,
-  .recommendation-row {
+  .recommendation-row,
+  .stats-metrics,
+  .stats-split {
     grid-template-columns: 1fr;
   }
 
   .recommendation-spotlight-card {
     min-height: 0;
+  }
+
+  .stats-panel-large {
+    min-height: 0;
+  }
+
+  .year-bar-row {
+    grid-template-columns: 3.2rem minmax(0, 1fr) 2rem;
   }
 
   .blog-posts-grid,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -413,6 +413,187 @@ h6 {
   margin-bottom: 0.5rem;
 }
 
+.eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--text-muted);
+  font-family: var(--font-family-heading);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-hero {
+  border-bottom: 1px solid var(--gray-line);
+  margin: 1.5rem 0 1rem;
+  padding: 1.25rem 0 1.75rem;
+  max-width: 58rem;
+}
+
+.home-hero h1 {
+  font-size: clamp(2rem, 5vw, 4.4rem);
+  line-height: 1.05;
+  max-width: 15ch;
+  margin-bottom: 1rem;
+}
+
+.home-hero p:not(.eyebrow) {
+  color: var(--text-muted);
+  font-size: 1.16rem;
+  max-width: 48rem;
+}
+
+.home-hero-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.home-section {
+  margin-top: 1.5rem;
+}
+
+.section-heading {
+  align-items: end;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 0.85rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+}
+
+.text-action,
+.text-button {
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid currentColor;
+  color: var(--text);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--font-family-heading);
+  font-size: 0.95rem;
+  font-weight: 700;
+  padding: 0 0 0.1rem;
+  text-decoration: none;
+}
+
+.text-action:hover,
+.text-button:hover {
+  color: var(--link-color);
+}
+
+.featured-post-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.featured-post-card {
+  background: var(--background-card);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  min-height: 15rem;
+  padding: 1rem;
+  text-decoration: none;
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.featured-post-card:hover {
+  border-color: var(--link-color);
+  transform: translateY(-2px);
+}
+
+.featured-post-card span,
+.compact-post-link span {
+  color: var(--text-muted);
+  font-family: var(--font-family-heading);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.featured-post-card h3 {
+  font-size: 1.12rem;
+  margin: 0.7rem 0;
+}
+
+.featured-post-card p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: auto 0 0;
+}
+
+.home-split {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.9fr);
+}
+
+.compact-post-list {
+  border-top: 1px solid var(--gray-line);
+}
+
+.compact-post-link {
+  align-items: baseline;
+  border-bottom: 1px solid var(--gray-line);
+  color: var(--text);
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 11rem minmax(0, 1fr);
+  padding: 0.75rem 0;
+  text-decoration: none;
+}
+
+.compact-post-link:hover strong {
+  color: var(--link-color);
+}
+
+.topic-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.topic-pill {
+  align-items: center;
+  background: var(--background-card);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  color: var(--text);
+  display: inline-flex;
+  font-family: var(--font-family-heading);
+  font-size: 0.9rem;
+  font-weight: 650;
+  gap: 0.45rem;
+  padding: 0.45rem 0.65rem;
+  text-decoration: none;
+}
+
+.topic-pill:hover {
+  border-color: var(--link-color);
+  color: var(--link-color);
+}
+
+.topic-pill span {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.til-strip {
+  background: var(--gray-bg);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  padding: 1rem;
+}
+
 /* ===========================================
    Navigation Styles
    =========================================== */
@@ -1292,6 +1473,21 @@ h6 {
    Responsive Adjustments
    =========================================== */
 @media (max-width: 768px) {
+  .featured-post-grid,
+  .home-split {
+    grid-template-columns: 1fr;
+  }
+
+  .compact-post-link {
+    gap: 0.2rem;
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading {
+    align-items: start;
+    flex-direction: column;
+  }
+
   .blog-posts-grid,
   .recommendations-grid {
     grid-template-columns: 1fr;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,12 +3,36 @@
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap");
 
 /* RESET */
-*, *::before, *::after { box-sizing: border-box; }
-* { margin: 0; padding: 0; }
-:target { scroll-margin-block: 5ex; }
-img, picture, video, canvas, svg { display: block; max-width: 100%; height: auto; }
-p, h1, h2, h3 { overflow-wrap: break-word; }
-body { min-height: 100vh; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+* {
+  margin: 0;
+  padding: 0;
+}
+:target {
+  scroll-margin-block: 5ex;
+}
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+p,
+h1,
+h2,
+h3 {
+  overflow-wrap: break-word;
+}
+body {
+  min-height: 100vh;
+}
 
 /** CSS Variables - Single Source of Truth **/
 :root {
@@ -18,7 +42,8 @@ body { min-height: 100vh; }
   --font-smaller: 0.75rem;
   --font-family-heading: "Space Grotesk", "Helvetica Neue", Arial, sans-serif;
   --font-family-body: "Literata", Georgia, serif;
-  --font-family-code: "JetBrains Mono", SFMono-Regular, Consolas, Menlo, monospace;
+  --font-family-code:
+    "JetBrains Mono", SFMono-Regular, Consolas, Menlo, monospace;
 
   /* Layout */
   --width: 575px;
@@ -201,15 +226,17 @@ li {
 
 /* Theme transition - smooth color changes */
 html {
-  transition: background-color 0.3s ease, color 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
 }
 
 html * {
-  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease,
+    box-shadow 0.3s ease;
 }
-
-
-
 
 a {
   color: var(--text);
@@ -229,7 +256,8 @@ a:hover {
   border-radius: 4px;
   background: color-mix(in srgb, var(--link-color) 10%, transparent);
   transition: all 0.2s ease;
-  border-bottom: 2px solid color-mix(in srgb, var(--link-color) 30%, transparent);
+  border-bottom: 2px solid
+    color-mix(in srgb, var(--link-color) 30%, transparent);
 }
 
 .inline-link:hover {
@@ -332,7 +360,8 @@ table {
   margin: 1.5rem 0;
 }
 
-th, td {
+th,
+td {
   padding: 0.75rem;
   text-align: left;
   border-bottom: 1px solid var(--gray-line);
@@ -366,7 +395,8 @@ img {
 }
 
 /* Lists in content */
-ul, ol {
+ul,
+ol {
   padding-left: 1.5rem;
   margin: 1rem 0;
 }
@@ -376,7 +406,12 @@ li {
   line-height: 1.6;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-family-heading);
   font-weight: 600;
   line-height: 1.3;
@@ -503,7 +538,9 @@ h6 {
   min-height: 15rem;
   padding: 1rem;
   text-decoration: none;
-  transition: border-color var(--transition-fast), transform var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    transform var(--transition-fast);
 }
 
 .featured-post-card:hover {
@@ -638,7 +675,8 @@ h6 {
 }
 
 .post-content a {
-  border-bottom: 1px solid color-mix(in srgb, var(--link-color) 45%, transparent);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--link-color) 45%, transparent);
   color: var(--link-color);
 }
 
@@ -900,7 +938,9 @@ h6 {
   flex-shrink: 0;
   color: var(--text-muted);
   font-size: 1.1rem;
-  transition: transform var(--transition-fast), color var(--transition-fast);
+  transition:
+    transform var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .blog-post-row:hover .blog-post-row-arrow {
@@ -1036,90 +1076,196 @@ h6 {
    Recommendations Grid
    =========================================== */
 .recommendations-container {
-  padding: var(--font-base);
-  max-width: 1200px;
+  max-width: 72rem;
   margin: 0 auto;
 }
 
-/* TL;DR Section */
-.tldr-section {
-  background: var(--gray-100);
-  border-radius: var(--radius);
-  padding: 1.75rem 2rem;
-  margin-bottom: 2.5rem;
+.recommendations-hero {
+  border-bottom: 1px solid var(--gray-line);
+  margin: 1.5rem 0;
+  max-width: 58rem;
+  padding-bottom: 1.5rem;
+}
+
+.recommendations-hero h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+  line-height: 1.05;
+  max-width: 13ch;
+  margin-bottom: 1rem;
+}
+
+.recommendations-hero p:not(.eyebrow) {
+  color: var(--text-muted);
+  font-size: 1.15rem;
+  max-width: 46rem;
+}
+
+.recommendation-metrics {
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 2rem;
+  overflow: hidden;
   border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
 }
 
-.tldr-title {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin: 0 0 1rem 0;
-  color: var(--accent);
+.recommendation-metrics div {
+  background: var(--background-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-height: 7rem;
+  padding: 1rem;
+  justify-content: end;
 }
 
-.tldr-list {
+.recommendation-metrics strong {
+  font-family: var(--font-family-heading);
+  font-size: clamp(1.7rem, 4vw, 3rem);
+  line-height: 1;
+}
+
+.recommendation-metrics span {
+  color: var(--text-muted);
+  font-family: var(--font-family-heading);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.recommendation-themes,
+.recommendation-spotlight,
+.recommendation-list-section {
+  margin-top: 2rem;
+}
+
+.recommendation-theme-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 0.6rem 2rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+  gap: 0.75rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
-.tldr-list li {
-  position: relative;
-  padding-left: 1.25rem;
-  font-size: 1.1rem;
-  line-height: 1.5;
-  color: var(--text);
-  margin: 0;
-}
-
-.tldr-list li::before {
-  content: "→";
-  position: absolute;
-  left: 0;
-  color: var(--link-color);
-  font-weight: 600;
-}
-
-.tldr-list li strong {
-  color: var(--accent);
-}
-
-.recommendations-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1.5rem;
-}
-
-.recommendation-card {
+.recommendation-theme {
   background: var(--background-card);
   border: 1px solid var(--gray-line);
-  border-radius: var(--radius);
-  padding: 1.5rem;
-  position: relative;
-  transition: all var(--transition-normal);
-  box-shadow: var(--shadow-card);
+  border-radius: var(--radius-small);
+  min-height: 8rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
-.recommendation-card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-card-hover);
-  border-color: var(--accent);
-}
-
-.recommendation-card::before {
-  content: '"';
-  position: absolute;
-  top: 0.75rem;
-  left: 1.25rem;
-  font-size: 3rem;
-  font-weight: 300;
-  color: var(--gray-line);
+.recommendation-theme span {
+  color: var(--link-color);
+  font-family: var(--font-family-heading);
+  font-size: 2rem;
+  font-weight: 700;
   line-height: 1;
-  font-family: Georgia, serif;
+}
+
+.recommendation-theme strong {
+  font-family: var(--font-family-heading);
+  line-height: 1.25;
+}
+
+.recommendation-spotlight-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.recommendation-spotlight-card,
+.recommendation-row {
+  background: var(--background-card);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+}
+
+.recommendation-spotlight-card {
+  display: flex;
+  flex-direction: column;
+  min-height: 26rem;
+  padding: 1.1rem;
+}
+
+.recommendation-spotlight-card blockquote {
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  flex: 1;
+  font-style: normal;
+  margin: 0;
+  padding: 0;
+}
+
+.recommendation-spotlight-card footer,
+.recommendation-person {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.recommendation-spotlight-card footer {
+  border-top: 1px solid var(--gray-line);
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.avatar {
+  align-items: center;
+  background: var(--gray-100);
+  border: 1px solid var(--gray-line);
+  border-radius: 999px;
+  color: var(--text);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-family: var(--font-family-heading);
+  font-size: 0.8rem;
+  font-weight: 800;
+  height: 2.5rem;
+  justify-content: center;
+  width: 2.5rem;
+}
+
+.recommendation-spotlight-card footer strong,
+.recommendation-person h3 {
+  display: block;
+  font-family: var(--font-family-heading);
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.recommendation-spotlight-card footer span,
+.recommendation-person p,
+.recommendation-person time {
+  color: var(--text-muted);
+  display: block;
+  font-family: var(--font-family-heading);
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.recommendations-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.recommendation-row {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: minmax(15rem, 0.7fr) minmax(0, 1.3fr);
+  padding: 1rem;
+}
+
+.recommendation-text {
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.65;
+  margin: 0;
 }
 
 /* ===========================================
@@ -1661,6 +1807,17 @@ h6 {
 
   .post-nav {
     grid-template-columns: 1fr;
+  }
+
+  .recommendation-metrics,
+  .recommendation-theme-grid,
+  .recommendation-spotlight-grid,
+  .recommendation-row {
+    grid-template-columns: 1fr;
+  }
+
+  .recommendation-spotlight-card {
+    min-height: 0;
   }
 
   .blog-posts-grid,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -594,6 +594,135 @@ h6 {
   padding: 1rem;
 }
 
+.post-shell {
+  max-width: 48rem;
+}
+
+.post-header {
+  border-bottom: 1px solid var(--gray-line);
+  margin: 1.5rem 0;
+  padding-bottom: 1.25rem;
+}
+
+.post-header h1 {
+  font-size: clamp(2rem, 5vw, 3.8rem);
+  line-height: 1.08;
+  margin-bottom: 1rem;
+}
+
+.post-meta {
+  color: var(--text-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-family: var(--font-family-heading);
+  font-size: 0.9rem;
+  font-weight: 600;
+  gap: 0.45rem 1rem;
+}
+
+.post-meta span + span::before {
+  color: var(--gray-line);
+  content: "/";
+  margin-right: 1rem;
+}
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.post-content {
+  font-size: 1.05rem;
+}
+
+.post-content a {
+  border-bottom: 1px solid color-mix(in srgb, var(--link-color) 45%, transparent);
+  color: var(--link-color);
+}
+
+.post-content a:hover {
+  border-bottom-color: var(--link-color);
+}
+
+.toc {
+  background: var(--gray-bg);
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  display: grid;
+  gap: 0.35rem;
+  margin: 0 0 1.5rem;
+  padding: 1rem;
+}
+
+.toc a {
+  color: var(--text);
+  font-family: var(--font-family-heading);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.toc a:hover {
+  color: var(--link-color);
+}
+
+.related-posts {
+  margin: 2rem 0;
+}
+
+.post-nav {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 1.5rem;
+}
+
+.post-nav a {
+  border: 1px solid var(--gray-line);
+  border-radius: var(--radius-small);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 6rem;
+  padding: 1rem;
+}
+
+.post-nav a:hover {
+  border-color: var(--link-color);
+}
+
+.post-nav span {
+  color: var(--text-muted);
+  font-family: var(--font-family-heading);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.post-nav strong {
+  line-height: 1.35;
+}
+
+.post-nav a:last-child {
+  text-align: right;
+}
+
+.topic-header {
+  border-bottom: 1px solid var(--gray-line);
+  margin: 1.5rem 0;
+  padding-bottom: 1rem;
+}
+
+.topic-header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.topic-header p:last-child {
+  color: var(--text-muted);
+}
+
 /* ===========================================
    Navigation Styles
    =========================================== */
@@ -1486,6 +1615,19 @@ h6 {
   .section-heading {
     align-items: start;
     flex-direction: column;
+  }
+
+  .post-meta {
+    flex-direction: column;
+  }
+
+  .post-meta span + span::before {
+    content: none;
+    margin-right: 0;
+  }
+
+  .post-nav {
+    grid-template-columns: 1fr;
   }
 
   .blog-posts-grid,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -727,13 +727,13 @@ h6 {
    Navigation Styles
    =========================================== */
 .site-nav {
-  margin-bottom: 1rem;
-  padding: 0.75rem 0;
+  margin-bottom: 1.25rem;
+  padding: 0.7rem 0;
   border-top: 1px solid var(--gray-line);
   border-bottom: 1px solid var(--gray-line);
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.25rem 0.8rem;
   align-items: center;
 }
 
@@ -748,37 +748,40 @@ h6 {
 }
 
 .nav-link {
-  color: white;
-  padding: 0.3rem 0.7rem;
-  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  padding: 0.1rem 0;
+  border-radius: 0;
   text-decoration: none;
-  font-size: 0.9rem;
-  font-weight: 600;
-  letter-spacing: 0.2px;
-  transition: all var(--transition-normal);
+  font-family: var(--font-family-heading);
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  transition: color var(--transition-fast);
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   position: relative;
   overflow: hidden;
 }
 
 .nav-link::before {
-  content: '';
+  content: "";
   position: absolute;
-  top: 0;
+  bottom: 0;
   left: 0;
   right: 0;
-  bottom: 0;
-  background: linear-gradient(180deg, rgba(255,255,255,0.15) 0%, rgba(255,255,255,0) 100%);
+  height: 1px;
+  background: currentColor;
+  opacity: 0;
   pointer-events: none;
 }
 
 .nav-link:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  color: white;
+  color: var(--text);
+}
+
+.nav-link:hover::before {
+  opacity: 1;
 }
 
 .nav-link:active {
@@ -791,7 +794,11 @@ h6 {
 }
 
 .nav-link--active {
-  box-shadow: 0 0 0 2px white, 0 4px 12px rgba(0, 0, 0, 0.2);
+  color: var(--text);
+}
+
+.nav-link--active::before {
+  opacity: 1;
 }
 
 .nav-icon {
@@ -799,14 +806,16 @@ h6 {
 }
 
 /* Navigation link colors with brand colors */
-.nav-link--about { background: var(--nav-about); }
-.nav-link--til { background: var(--nav-til); }
-.nav-link--stats { background: var(--nav-stats); }
-.nav-link--recommendations { background: var(--nav-recommendations); }
-.nav-link--resume { background: var(--nav-resume); }
-.nav-link--linkedin { background: var(--nav-linkedin); }
-.nav-link--twitter { background: var(--nav-twitter); }
-.nav-link--github { background: var(--nav-github); }
+.nav-link--about,
+.nav-link--til,
+.nav-link--stats,
+.nav-link--recommendations,
+.nav-link--resume,
+.nav-link--linkedin,
+.nav-link--twitter,
+.nav-link--github {
+  background: transparent;
+}
 
 /* Separator between nav groups */
 .nav-separator {
@@ -1130,9 +1139,17 @@ h6 {
 .search-icon {
   position: absolute;
   left: 0.75rem;
-  font-size: 1rem;
+  align-items: center;
+  border: 1px solid var(--gray-line);
+  border-radius: 4px;
+  color: var(--text-muted);
+  display: inline-flex;
+  font-family: var(--font-family-code);
+  font-size: 0.72rem;
+  height: 1.15rem;
+  justify-content: center;
+  width: 1.15rem;
   pointer-events: none;
-  opacity: 0.6;
 }
 
 .search-input {
@@ -1209,7 +1226,8 @@ h6 {
   border-bottom: none;
 }
 
-.search-result-item:hover {
+.search-result-item:hover,
+.search-result-item.active {
   background: var(--gray-100);
 }
 
@@ -1222,12 +1240,27 @@ h6 {
 }
 
 .search-result-featured {
-  font-size: 0.9rem;
+  border: 1px solid var(--gray-line);
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  padding: 0.05rem 0.3rem;
 }
 
 .search-result-date {
   font-size: 0.9rem;
   color: var(--text-muted);
+}
+
+.search-result-description {
+  color: var(--text-muted);
+  display: -webkit-box;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  margin: 0.25rem 0 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .search-no-results {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -4,13 +4,18 @@ import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import { rhythm, scale } from "../utils/typography"
+import { rhythm } from "../utils/typography"
+import { getPostDescription, getPostTitle, getTopicSlug, normalizeTags } from "../utils/content"
 import blog from "../../content/assets/blog.jpg"
 
 const BlogPostTemplate = ({ data, location, pageContext }) => {
   const post = data.markdownRemark
   const siteTitle = data.site.siteMetadata.title
   const { previous, next } = pageContext
+  const tags = normalizeTags(post.frontmatter.tags)
+  const relatedPosts = data.relatedPosts.edges.filter(
+    ({ node }) => node.fields.slug !== post.fields.slug
+  )
 
   return (
     <Layout location={location} title={siteTitle}>
@@ -20,55 +25,82 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
       <Seo
         title={post.frontmatter.title}
         description={post.frontmatter.description || post.excerpt}
+        pathname={location.pathname}
+        type="article"
+        date={post.frontmatter.dateISO}
+        tags={tags}
       />
-      <h1
-        style={{
-          marginTop: rhythm(1),
-          marginBottom: 0,
-        }}
-      >
-        {post.frontmatter.title}
-      </h1>
-      <p
-        style={{
-          ...scale(-1 / 5),
-          display: `block`,
-          marginBottom: rhythm(1),
-        }}
-      >
-        {post.frontmatter.date}
-      </p>
-      <div dangerouslySetInnerHTML={{ __html: post.html }} />
+      <article className="post-shell">
+        <header className="post-header">
+          <p className="eyebrow">Essay</p>
+          <h1>{post.frontmatter.title}</h1>
+          <div className="post-meta">
+            <span>{post.frontmatter.date}</span>
+            <span>{post.timeToRead} min read</span>
+            {post.wordCount?.words && <span>{post.wordCount.words.toLocaleString()} words</span>}
+          </div>
+          {tags.length > 0 && (
+            <div className="post-tags">
+              {tags.map(tag => (
+                <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
+                  {tag}
+                </Link>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {post.headings.length > 2 && (
+          <nav className="toc" aria-label="Table of contents">
+            <p className="eyebrow">Contents</p>
+            {post.headings.map(heading => (
+              <a key={heading.id} href={`#${heading.id}`}>
+                {heading.value}
+              </a>
+            ))}
+          </nav>
+        )}
+
+        <div className="post-content" dangerouslySetInnerHTML={{ __html: post.html }} />
+      </article>
       <hr
         style={{
           marginBottom: rhythm(1),
         }}
       />
-      <ul
-        style={{
-          display: `flex`,
-          flexWrap: `wrap`,
-          justifyContent: `space-between`,
-          listStyle: `none`,
-          marginLeft: 0,
-          padding: 0,
-        }}
-      >
-        <li>
-          {previous && (
-            <Link to={previous.fields.slug} rel="prev">
-              ← {previous.frontmatter.title}
-            </Link>
-          )}
-        </li>
-        <li>
-          {next && (
-            <Link to={next.fields.slug} rel="next">
-              {next.frontmatter.title} →
-            </Link>
-          )}
-        </li>
-      </ul>
+      {relatedPosts.length > 0 && (
+        <section className="related-posts">
+          <div className="section-heading">
+            <div>
+              <p className="eyebrow">Keep Reading</p>
+              <h2>Related Posts</h2>
+            </div>
+          </div>
+          <div className="compact-post-list">
+            {relatedPosts.map(({ node }) => (
+              <Link key={node.fields.slug} to={node.fields.slug} className="compact-post-link">
+                <span>{node.frontmatter.date}</span>
+                <strong>{getPostTitle(node)}</strong>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <nav className="post-nav" aria-label="Post navigation">
+        {previous ? (
+          <Link to={previous.fields.slug} rel="prev">
+            <span>Previous</span>
+            <strong>{previous.frontmatter.title}</strong>
+          </Link>
+        ) : <span />}
+        {next ? (
+          <Link to={next.fields.slug} rel="next">
+            <span>Next</span>
+            <strong>{next.frontmatter.title}</strong>
+          </Link>
+        ) : <span />}
+      </nav>
     </Layout>
   )
 }
@@ -76,7 +108,7 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
 export default BlogPostTemplate
 
 export const pageQuery = graphql`
-  query BlogPostBySlug($slug: String!) {
+  query BlogPostBySlug($slug: String!, $tags: [String]) {
     site {
       siteMetadata {
         title
@@ -87,10 +119,45 @@ export const pageQuery = graphql`
       id
       excerpt(pruneLength: 300)
       html
+      headings(depth: h2) {
+        id
+        value
+      }
+      timeToRead
+      wordCount {
+        words
+      }
+      fields {
+        slug
+      }
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
+        dateISO: date(formatString: "YYYY-MM-DD")
         description
+        tags
+      }
+    }
+    relatedPosts: allMarkdownRemark(
+      sort: { frontmatter: { date: DESC } }
+      filter: {
+        fields: { collection: { eq: "blog" } }
+        frontmatter: { tags: { in: $tags } }
+      }
+      limit: 4
+    ) {
+      edges {
+        node {
+          excerpt(pruneLength: 140)
+          fields {
+            slug
+          }
+          frontmatter {
+            date(formatString: "MMMM DD, YYYY")
+            title
+            description
+          }
+        }
       }
     }
   }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -5,7 +5,12 @@ import { Helmet } from "react-helmet"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import { rhythm } from "../utils/typography"
-import { getPostDescription, getPostTitle, getTopicSlug, normalizeTags } from "../utils/content"
+import {
+  getPostDescription,
+  getPostTitle,
+  getTopicSlug,
+  normalizeTags,
+} from "../utils/content"
 import blog from "../../content/assets/blog.jpg"
 
 const BlogPostTemplate = ({ data, location, pageContext }) => {
@@ -37,11 +42,13 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
           <div className="post-meta">
             <span>{post.frontmatter.date}</span>
             <span>{post.timeToRead} min read</span>
-            {post.wordCount?.words && <span>{post.wordCount.words.toLocaleString()} words</span>}
+            {post.wordCount?.words && (
+              <span>{post.wordCount.words.toLocaleString()} words</span>
+            )}
           </div>
           {tags.length > 0 && (
             <div className="post-tags">
-              {tags.map(tag => (
+              {tags.map((tag) => (
                 <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
                   {tag}
                 </Link>
@@ -53,7 +60,7 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
         {post.headings.length > 2 && (
           <nav className="toc" aria-label="Table of contents">
             <p className="eyebrow">Contents</p>
-            {post.headings.map(heading => (
+            {post.headings.map((heading) => (
               <a key={heading.id} href={`#${heading.id}`}>
                 {heading.value}
               </a>
@@ -61,7 +68,10 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
           </nav>
         )}
 
-        <div className="post-content" dangerouslySetInnerHTML={{ __html: post.html }} />
+        <div
+          className="post-content"
+          dangerouslySetInnerHTML={{ __html: post.html }}
+        />
       </article>
       <hr
         style={{
@@ -78,7 +88,11 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
           </div>
           <div className="compact-post-list">
             {relatedPosts.map(({ node }) => (
-              <Link key={node.fields.slug} to={node.fields.slug} className="compact-post-link">
+              <Link
+                key={node.fields.slug}
+                to={node.fields.slug}
+                className="compact-post-link"
+              >
                 <span>{node.frontmatter.date}</span>
                 <strong>{getPostTitle(node)}</strong>
               </Link>
@@ -93,13 +107,17 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
             <span>Previous</span>
             <strong>{previous.frontmatter.title}</strong>
           </Link>
-        ) : <span />}
+        ) : (
+          <span />
+        )}
         {next ? (
           <Link to={next.fields.slug} rel="next">
             <span>Next</span>
             <strong>{next.frontmatter.title}</strong>
           </Link>
-        ) : <span />}
+        ) : (
+          <span />
+        )}
       </nav>
     </Layout>
   )

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
@@ -11,7 +10,6 @@ import {
   getTopicSlug,
   normalizeTags,
 } from "../utils/content"
-import blog from "../../content/assets/blog.jpg"
 
 const BlogPostTemplate = ({ data, location, pageContext }) => {
   const post = data.markdownRemark
@@ -24,17 +22,6 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Helmet>
-        <meta name="twitter:image" content={blog} />
-      </Helmet>
-      <Seo
-        title={post.frontmatter.title}
-        description={post.frontmatter.description || post.excerpt}
-        pathname={location.pathname}
-        type="article"
-        date={post.frontmatter.dateISO}
-        tags={tags}
-      />
       <article className="post-shell">
         <header className="post-header">
           <p className="eyebrow">Essay</p>
@@ -124,6 +111,22 @@ const BlogPostTemplate = ({ data, location, pageContext }) => {
 }
 
 export default BlogPostTemplate
+
+export const Head = ({ data, location }) => {
+  const post = data.markdownRemark
+  const tags = normalizeTags(post.frontmatter.tags)
+
+  return (
+    <Seo
+      title={post.frontmatter.title}
+      description={post.frontmatter.description || post.excerpt}
+      pathname={location.pathname}
+      type="article"
+      date={post.frontmatter.dateISO}
+      tags={tags}
+    />
+  )
+}
 
 export const pageQuery = graphql`
   query BlogPostBySlug($slug: String!, $tags: [String]) {

--- a/src/templates/til-post.js
+++ b/src/templates/til-post.js
@@ -4,13 +4,15 @@ import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import { rhythm, scale } from "../utils/typography"
+import { rhythm } from "../utils/typography"
+import { getTopicSlug, normalizeTags } from "../utils/content"
 import blog from "../../content/assets/blog.jpg"
 
 const TilPostTemplate = ({ data, location, pageContext }) => {
   const post = data.markdownRemark
   const siteTitle = data.site.siteMetadata.title
   const { previous, next } = pageContext
+  const tags = normalizeTags(post.frontmatter.tags)
 
   return (
     <Layout location={location} title={siteTitle}>
@@ -20,92 +22,33 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
       <Seo
         title={post.frontmatter.title}
         description={post.frontmatter.description || post.excerpt}
+        pathname={location.pathname}
+        type="article"
+        date={post.frontmatter.dateISO}
+        tags={tags}
       />
 
-      {/* TIL Badge */}
-      <div
-        style={{
-          display: "inline-block",
-          backgroundColor: "var(--nav-til)",
-          color: "white",
-          padding: "0.5rem 1rem",
-          borderRadius: "var(--radius-pill)",
-          fontSize: "0.9rem",
-          fontWeight: "600",
-          marginBottom: rhythm(1),
-          letterSpacing: "0.5px",
-          textTransform: "uppercase",
-        }}
-      >
-        Today I Learned
-      </div>
-
-      <h1
-        style={{
-          marginTop: rhythm(0.5),
-          marginBottom: 0,
-          fontSize: "2rem",
-          lineHeight: "1.2",
-        }}
-      >
-        {post.frontmatter.title}
-      </h1>
-
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "1rem",
-          marginBottom: rhythm(1),
-          flexWrap: "wrap",
-        }}
-      >
-        <p
-          style={{
-            ...scale(-1 / 5),
-            display: `block`,
-            margin: 0,
-            color: "var(--gray-text)",
-          }}
-        >
-          {post.frontmatter.date}
-        </p>
-
-        {/* Tags */}
-        {post.frontmatter.tags && (
-          <div
-            style={{
-              display: "flex",
-              gap: "0.5rem",
-              flexWrap: "wrap",
-            }}
-          >
-            {post.frontmatter.tags.map((tag, index) => (
-              <span
-                key={index}
-                style={{
-                  backgroundColor: "var(--gray-100)",
-                  color: "var(--gray-700)",
-                  padding: "0.25rem 0.75rem",
-                  borderRadius: "var(--radius)",
-                  fontSize: "0.85rem",
-                  fontWeight: "500",
-                }}
-              >
-                #{tag}
-              </span>
-            ))}
+      <article className="post-shell til-post">
+        <header className="post-header">
+          <p className="eyebrow">Today I Learned</p>
+          <h1>{post.frontmatter.title}</h1>
+          <div className="post-meta">
+            <span>{post.frontmatter.date}</span>
+            <span>{post.timeToRead || 2} min read</span>
           </div>
-        )}
-      </div>
+          {tags.length > 0 && (
+            <div className="post-tags">
+              {tags.map(tag => (
+                <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
+                  {tag}
+                </Link>
+              ))}
+            </div>
+          )}
+        </header>
 
-      <div
-        style={{
-          fontSize: "1.1rem",
-          lineHeight: "1.7",
-        }}
-        dangerouslySetInnerHTML={{ __html: post.html }}
-      />
+        <div className="post-content" dangerouslySetInnerHTML={{ __html: post.html }} />
+      </article>
 
       <hr
         style={{
@@ -114,32 +57,20 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
         }}
       />
 
-      {/* Navigation */}
-      <ul
-        style={{
-          display: `flex`,
-          flexWrap: `wrap`,
-          justifyContent: `space-between`,
-          listStyle: `none`,
-          marginLeft: 0,
-          padding: 0,
-        }}
-      >
-        <li>
-          {previous && (
-            <Link to={previous.fields.slug} rel="prev">
-              ← {previous.frontmatter.title}
-            </Link>
-          )}
-        </li>
-        <li>
-          {next && (
-            <Link to={next.fields.slug} rel="next">
-              {next.frontmatter.title} →
-            </Link>
-          )}
-        </li>
-      </ul>
+      <nav className="post-nav" aria-label="TIL navigation">
+        {previous ? (
+          <Link to={previous.fields.slug} rel="prev">
+            <span>Previous</span>
+            <strong>{previous.frontmatter.title}</strong>
+          </Link>
+        ) : <span />}
+        {next ? (
+          <Link to={next.fields.slug} rel="next">
+            <span>Next</span>
+            <strong>{next.frontmatter.title}</strong>
+          </Link>
+        ) : <span />}
+      </nav>
 
       {/* Back to TIL */}
       <div
@@ -178,9 +109,11 @@ export const pageQuery = graphql`
       id
       excerpt(pruneLength: 300)
       html
+      timeToRead
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
+        dateISO: date(formatString: "YYYY-MM-DD")
         description
         tags
       }

--- a/src/templates/til-post.js
+++ b/src/templates/til-post.js
@@ -38,7 +38,7 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
           </div>
           {tags.length > 0 && (
             <div className="post-tags">
-              {tags.map(tag => (
+              {tags.map((tag) => (
                 <Link key={tag} to={getTopicSlug(tag)} className="topic-pill">
                   {tag}
                 </Link>
@@ -47,7 +47,10 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
           )}
         </header>
 
-        <div className="post-content" dangerouslySetInnerHTML={{ __html: post.html }} />
+        <div
+          className="post-content"
+          dangerouslySetInnerHTML={{ __html: post.html }}
+        />
       </article>
 
       <hr
@@ -63,13 +66,17 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
             <span>Previous</span>
             <strong>{previous.frontmatter.title}</strong>
           </Link>
-        ) : <span />}
+        ) : (
+          <span />
+        )}
         {next ? (
           <Link to={next.fields.slug} rel="next">
             <span>Next</span>
             <strong>{next.frontmatter.title}</strong>
           </Link>
-        ) : <span />}
+        ) : (
+          <span />
+        )}
       </nav>
 
       {/* Back to TIL */}

--- a/src/templates/til-post.js
+++ b/src/templates/til-post.js
@@ -1,12 +1,10 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-import { Helmet } from "react-helmet"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import { rhythm } from "../utils/typography"
 import { getTopicSlug, normalizeTags } from "../utils/content"
-import blog from "../../content/assets/blog.jpg"
 
 const TilPostTemplate = ({ data, location, pageContext }) => {
   const post = data.markdownRemark
@@ -16,18 +14,6 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Helmet>
-        <meta name="twitter:image" content={blog} />
-      </Helmet>
-      <Seo
-        title={post.frontmatter.title}
-        description={post.frontmatter.description || post.excerpt}
-        pathname={location.pathname}
-        type="article"
-        date={post.frontmatter.dateISO}
-        tags={tags}
-      />
-
       <article className="post-shell til-post">
         <header className="post-header">
           <p className="eyebrow">Today I Learned</p>
@@ -103,6 +89,22 @@ const TilPostTemplate = ({ data, location, pageContext }) => {
 }
 
 export default TilPostTemplate
+
+export const Head = ({ data, location }) => {
+  const post = data.markdownRemark
+  const tags = normalizeTags(post.frontmatter.tags)
+
+  return (
+    <Seo
+      title={post.frontmatter.title}
+      description={post.frontmatter.description || post.excerpt}
+      pathname={location.pathname}
+      type="article"
+      date={post.frontmatter.dateISO}
+      tags={tags}
+    />
+  )
+}
 
 export const pageQuery = graphql`
   query TilPostBySlug($slug: String!) {

--- a/src/templates/topic-page.js
+++ b/src/templates/topic-page.js
@@ -21,17 +21,25 @@ const TopicPage = ({ data, location, pageContext }) => {
       <header className="topic-header">
         <p className="eyebrow">Topic</p>
         <h1>{tag}</h1>
-        <p>{posts.length} post{posts.length === 1 ? "" : "s"} in this topic.</p>
+        <p>
+          {posts.length} post{posts.length === 1 ? "" : "s"} in this topic.
+        </p>
       </header>
 
       <div className="blog-posts-list">
         {posts.map(({ node }) => (
-          <Link key={node.fields.slug} to={node.fields.slug} className="blog-post-row">
+          <Link
+            key={node.fields.slug}
+            to={node.fields.slug}
+            className="blog-post-row"
+          >
             <div className="blog-post-row-header">
               <div className="blog-post-row-meta">
                 <h2 className="blog-post-row-title">{getPostTitle(node)}</h2>
               </div>
-              <span className="blog-post-row-arrow" aria-hidden="true">→</span>
+              <span className="blog-post-row-arrow" aria-hidden="true">
+                →
+              </span>
             </div>
             <span className="blog-post-row-date">{node.frontmatter.date}</span>
             <p className="blog-post-row-excerpt">{getPostDescription(node)}</p>

--- a/src/templates/topic-page.js
+++ b/src/templates/topic-page.js
@@ -1,0 +1,73 @@
+import React from "react"
+import { Link, graphql } from "gatsby"
+
+import Layout from "../components/layout"
+import Seo from "../components/seo"
+import { getPostDescription, getPostTitle } from "../utils/content"
+
+const TopicPage = ({ data, location, pageContext }) => {
+  const siteTitle = data.site.siteMetadata.title
+  const posts = data.allMarkdownRemark.edges
+  const { tag } = pageContext
+
+  return (
+    <Layout location={location} title={siteTitle}>
+      <Seo
+        title={`Topic: ${tag}`}
+        description={`Writing by Vinit Kumar about ${tag}.`}
+        pathname={location.pathname}
+      />
+
+      <header className="topic-header">
+        <p className="eyebrow">Topic</p>
+        <h1>{tag}</h1>
+        <p>{posts.length} post{posts.length === 1 ? "" : "s"} in this topic.</p>
+      </header>
+
+      <div className="blog-posts-list">
+        {posts.map(({ node }) => (
+          <Link key={node.fields.slug} to={node.fields.slug} className="blog-post-row">
+            <div className="blog-post-row-header">
+              <div className="blog-post-row-meta">
+                <h2 className="blog-post-row-title">{getPostTitle(node)}</h2>
+              </div>
+              <span className="blog-post-row-arrow" aria-hidden="true">→</span>
+            </div>
+            <span className="blog-post-row-date">{node.frontmatter.date}</span>
+            <p className="blog-post-row-excerpt">{getPostDescription(node)}</p>
+          </Link>
+        ))}
+      </div>
+    </Layout>
+  )
+}
+
+export default TopicPage
+
+export const pageQuery = graphql`
+  query TopicPageByTag($tag: String!) {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+    allMarkdownRemark(
+      sort: { frontmatter: { date: DESC } }
+      filter: { frontmatter: { tags: { in: [$tag] } } }
+    ) {
+      edges {
+        node {
+          excerpt(pruneLength: 180)
+          fields {
+            slug
+          }
+          frontmatter {
+            date(formatString: "MMMM DD, YYYY")
+            title
+            description
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/templates/topic-page.js
+++ b/src/templates/topic-page.js
@@ -12,12 +12,6 @@ const TopicPage = ({ data, location, pageContext }) => {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Seo
-        title={`Topic: ${tag}`}
-        description={`Writing by Vinit Kumar about ${tag}.`}
-        pathname={location.pathname}
-      />
-
       <header className="topic-header">
         <p className="eyebrow">Topic</p>
         <h1>{tag}</h1>
@@ -51,6 +45,14 @@ const TopicPage = ({ data, location, pageContext }) => {
 }
 
 export default TopicPage
+
+export const Head = ({ location, pageContext }) => (
+  <Seo
+    title={`Topic: ${pageContext.tag}`}
+    description={`Writing by Vinit Kumar about ${pageContext.tag}.`}
+    pathname={location.pathname}
+  />
+)
 
 export const pageQuery = graphql`
   query TopicPageByTag($tag: String!) {

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -1,19 +1,19 @@
-const normalizeTag = tag =>
+const normalizeTag = (tag) =>
   String(tag || "")
     .trim()
     .toLowerCase()
     .replace(/\s+/g, "-")
 
-export const normalizeTags = tags => {
+export const normalizeTags = (tags) => {
   if (!tags) return []
   const rawTags = Array.isArray(tags) ? tags : String(tags).split(/[,\s]+/)
 
   return Array.from(new Set(rawTags.map(normalizeTag).filter(Boolean)))
 }
 
-export const getPostDescription = node =>
+export const getPostDescription = (node) =>
   node.frontmatter.description || node.excerpt || ""
 
-export const getPostTitle = node => node.frontmatter.title || node.fields.slug
+export const getPostTitle = (node) => node.frontmatter.title || node.fields.slug
 
-export const getTopicSlug = tag => `/topics/${normalizeTag(tag)}/`
+export const getTopicSlug = (tag) => `/topics/${normalizeTag(tag)}/`

--- a/src/utils/content.js
+++ b/src/utils/content.js
@@ -1,0 +1,19 @@
+const normalizeTag = tag =>
+  String(tag || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+
+export const normalizeTags = tags => {
+  if (!tags) return []
+  const rawTags = Array.isArray(tags) ? tags : String(tags).split(/[,\s]+/)
+
+  return Array.from(new Set(rawTags.map(normalizeTag).filter(Boolean)))
+}
+
+export const getPostDescription = node =>
+  node.frontmatter.description || node.excerpt || ""
+
+export const getPostTitle = node => node.frontmatter.title || node.fields.slug
+
+export const getTopicSlug = tag => `/topics/${normalizeTag(tag)}/`


### PR DESCRIPTION
## What changed

- Added normalized topic pages at `/topics/:tag/`.
- Redesigned the homepage around editorial discovery: hero, featured writing, latest posts, topics, TIL preview, and archive.
- Enriched blog and TIL post pages with metadata, tags, table of contents, related posts, and stronger navigation.
- Refined navigation, search, stats, and recommendations pages for a cleaner publication-style experience.
- Improved SEO metadata with canonical URLs, article metadata, and JSON-LD using Gatsby Head.
- Removed the runtime `@latest` unpkg code-highlighting script.
- Removed `gatsby-plugin-react-helmet` / `react-helmet` usage and routed legacy Gatsby build-time `punycode` imports to the userland package.

## Why

The site had strong content but the UI behaved mostly like a flat archive. These changes make the best writing easier to discover, make topic browsing possible, and improve the reading experience without changing the content model more than necessary.

## Validation

- Ran `npm run build` successfully.
- Build output is clean of the previous `gatsby-plugin-react-helmet` migration warning and Node `punycode` deprecation warning.