### PR TITLE
Publish fff-plus.nvim fzf.vim parity update

### DIFF
--- a/content/blog/fff-plus-fzf-vim-parity/index.md
+++ b/content/blog/fff-plus-fzf-vim-parity/index.md
@@ -1,0 +1,120 @@
+---
+title: "Closing the fzf.vim Gaps in fff-plus.nvim"
+date: "2026-07-20"
+description: "How fff-plus.nvim gained fuzzy matching, correct Git pickers, multi-select actions, fullscreen layouts, and Git diff previews without growing beyond its extension-plugin role."
+tags: ["neovim", "lua", "git", "open-source", "plugins"]
+featured: true
+---
+
+Earlier this month, I wrote about why I moved my extra [`fff.nvim`](https://github.com/dmtrKovalenko/fff.nvim) pickers into a separate extension plugin: [`fff-plus.nvim`](https://github.com/vinitkumar/fff-plus.nvim). The architecture felt right, but the pickers still lacked some behavior I relied on in `fzf.vim`.
+
+I have now closed the most important of those gaps in [fff-plus.nvim PR #7](https://github.com/vinitkumar/fff-plus.nvim/pull/7).
+
+This update is less about adding a long list of new pickers and more about making the existing ones behave like complete daily tools. Buffers, colorschemes, tracked files, and Git status files now share fuzzy matching, correct long-list scrolling, better actions, and consistent layouts.
+
+## See it in action
+
+The demo shows tracked-file search, Git-status diff previews, multi-select and quickfix, and the fullscreen buffer picker.
+
+<media-controller class="fff-plus-demo-player" aria-label="fff-plus.nvim picker usage demo">
+  <video slot="media" playsinline preload="metadata" crossorigin>
+    <source src="https://cdn.jsdelivr.net/gh/vinitkumar/fff-plus.nvim@59efd2fcb44146b84a0176b48fc42cffccf22c77/assets/fff-plus-usage.mp4" type="video/mp4" />
+    Your browser cannot play this video. <a href="https://cdn.jsdelivr.net/gh/vinitkumar/fff-plus.nvim@59efd2fcb44146b84a0176b48fc42cffccf22c77/assets/fff-plus-usage.mp4">Open the MP4 directly.</a>
+  </video>
+  <media-play-button slot="centered-chrome" aria-label="Play demo"></media-play-button>
+  <media-control-bar>
+    <media-play-button></media-play-button>
+    <media-seek-backward-button seekoffset="10"></media-seek-backward-button>
+    <media-seek-forward-button seekoffset="10"></media-seek-forward-button>
+    <media-time-display showduration></media-time-display>
+    <media-time-range></media-time-range>
+    <media-playback-rate-button rates="0.5 1 1.25 1.5 2"></media-playback-rate-button>
+    <media-pip-button></media-pip-button>
+    <media-fullscreen-button></media-fullscreen-button>
+  </media-control-bar>
+</media-controller>
+
+## An audit before implementation
+
+I started by comparing the combined `fff.nvim` and `fff-plus.nvim` experience with `fzf.vim`. That audit helped separate two kinds of missing work.
+
+The first kind was new picker families: lines, marks, jumps, history, tags, commits, commands, and help. Those deserve a reusable extension-picker framework rather than a collection of one-off implementations.
+
+The second kind was shared behavior missing from the pickers that already existed. This was the right scope for the current update:
+
+- ranked fuzzy matching instead of literal substring filtering,
+- a viewport that follows the selected item through long lists,
+- correct tracked-file and Git-status semantics,
+- multi-select, quickfix, paste, split, vertical split, and tab actions,
+- fullscreen command layouts,
+- existing-window jumps for buffers,
+- and diff previews for changed Git files.
+
+Fixing these foundations gives every current picker a better baseline and gives future pickers less behavior to reinvent.
+
+## `:GFiles` now means tracked files
+
+The old Git picker had a naming problem. `git_files()` used `git status -s`, while the optional `:GFiles` compatibility command suggested the `fzf.vim` behavior: files tracked by Git.
+
+Those are different sources, so the plugin now exposes both explicitly:
+
+| Workflow | Lua API | Command |
+| --- | --- | --- |
+| Tracked files | `require("fff_plus").tracked_files()` | `:FFFPlusGitFiles` |
+| Changed files | `require("fff_plus").git_status()` | `:FFFPlusGitStatus` |
+
+With legacy commands enabled, `:GFiles` now opens tracked files, matching `fzf.vim`. The older `git_files()` API and `:FFFPlusGFiles` command remain compatibility aliases for the Git-status picker, so existing configurations do not break immediately.
+
+The Git source also moved to NUL-delimited parsing. That matters for filenames containing spaces, tabs, or other characters that line-oriented parsing can mishandle. Rename records are parsed explicitly instead of being guessed from display text.
+
+## Shared actions across file-like pickers
+
+The buffer and Git pickers now support the same practical actions as the upstream FFF picker defaults:
+
+| Action | Default key |
+| --- | --- |
+| Toggle selection | `<Tab>` |
+| Send selected or current entries to quickfix | `<C-q>` |
+| Open in a horizontal split | `<C-s>` |
+| Open in a vertical split | `<C-v>` |
+| Open in a tab | `<C-t>` |
+| Paste selected or current paths | `<A-CR>` |
+
+Selection behavior lives in a shared module, which is important. Multi-select should not be subtly reimplemented by each picker. The buffer picker can also jump to a window that already displays the selected buffer:
+
+```lua
+require("fff_plus").buffers({
+  jump_to_existing = true,
+  keymaps = { paste = "<M-p>" },
+})
+```
+
+## Better ranking and long-list behavior
+
+The extension pickers previously used case-insensitive substring matching. That worked for small lists, but it did not feel like a fuzzy finder. They now use a shared ranked matcher, so non-contiguous queries produce useful results and stronger matches rise to the top.
+
+The rendering code also has a real viewport now. Moving beyond the visible rows keeps the selected item on screen instead of advancing an invisible cursor. This sounds like a small detail, but it is the difference between a picker that works in a demo and one that works with a large repository or a long buffer list.
+
+The same ranking is preserved whether the prompt is at the top or the bottom, with regression tests covering both layouts.
+
+## Fullscreen layouts and useful Git previews
+
+Adding `!` to an extension command now opens it fullscreen:
+
+```vim
+:FFFPlusBuffers!
+:FFFPlusGitFiles!
+:FFFPlusGitStatus!
+```
+
+The Git-status picker now previews the actual diff when it can. If a diff is not available, it falls back to file contents. That makes the picker useful for reviewing a working tree, not just navigating it.
+
+## The extension stays deliberately small
+
+This update adds a lot of capability, but it does not change the plugin boundary. Upstream `fff.nvim` still owns the Rust backend, file indexing, live grep, frecency, binary downloads, and releases. `fff-plus.nvim` remains a Lua extension for extra picker workflows.
+
+The next architectural step is to extract a reusable extension-picker framework before adding the deferred picker families. That should make lines, history, marks, jumps, tags, commits, commands, and help easier to build without copying large picker implementations.
+
+For now, the existing pickers are considerably closer to the `fzf.vim` workflows that inspired them.
+
+You can read the full change in [PR #7](https://github.com/vinitkumar/fff-plus.nvim/pull/7), see the [current configuration and command reference](https://github.com/vinitkumar/fff-plus.nvim#readme), or start with my earlier post, [fff-plus.nvim: The Better Shape for My fff.nvim Picker Work](/fff-plus-nvim-extension/).

--- a/content/blog/fff-plus-nvim-extension/index.md
+++ b/content/blog/fff-plus-nvim-extension/index.md
@@ -8,6 +8,8 @@ featured: true
 
 I recently released [fff-plus.nvim](https://github.com/vinitkumar/fff-plus.nvim), a small extension plugin for [fff.nvim](https://github.com/dmtrKovalenko/fff.nvim).
 
+> **Update, July 20, 2026:** The Git APIs and commands described below have evolved. Read [Closing the fzf.vim Gaps in fff-plus.nvim](/fff-plus-fzf-vim-parity/) for the new tracked-file and Git-status split, fuzzy matching, multi-select actions, fullscreen layouts, and diff previews.
+
 This is the next version of an idea I wrote about earlier in [Why I Forked fff.nvim and Turned It Into a Complete Picker Ecosystem](/fff-nvim-fork/). That post was about my [old `fff.nvim` fork](https://github.com/vinitkumar/fff.nvim), where I added the picker workflows I missed from `fzf.vim`: buffers, git status files, and colorschemes.
 
 The fork worked. It solved my problem. But after living with it for a while, I think `fff-plus.nvim` is the better idea.

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,6 @@
 import './src/styles/global.css';
 import { defineCustomElements as deckDeckGoHighlightElement } from "@deckdeckgo/highlight-code/dist/loader";
+import "media-chrome";
 
 // Initialize the highlight-code web component
 // This is required for code highlighting to work on direct page loads (not just client-side navigation)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gatsby-source-filesystem": "^5.16.0",
     "gatsby-transformer-remark": "^6.16.0",
     "gatsby-transformer-sharp": "^5.16.0",
+    "media-chrome": "^4.19.2",
     "prismjs": "^1.30.0",
     "punycode": "^2.3.1",
     "react": "^18.3.1",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -875,6 +875,78 @@ h6 {
   border-bottom-color: var(--link-color);
 }
 
+.post-content table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.post-content .fff-plus-demo-player {
+  --media-button-icon-height: 1.35rem;
+  --media-button-icon-width: 1.35rem;
+  --media-control-background: transparent;
+  --media-control-color: #fff;
+  --media-control-hover-background: rgba(255, 255, 255, 0.14);
+  --media-range-bar-color: #fb923c;
+  --media-range-thumb-background: #fff;
+  --media-range-track-background: rgba(255, 255, 255, 0.32);
+  aspect-ratio: 16 / 9;
+  background: #08090d;
+  border: 1px solid rgba(251, 146, 60, 0.42);
+  border-radius: 0.8rem;
+  box-shadow:
+    0 1.2rem 3rem rgba(8, 9, 13, 0.25),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+  display: block;
+  margin: 1.5rem 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.fff-plus-demo-player video {
+  background: #08090d;
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.fff-plus-demo-player media-control-bar {
+  background: linear-gradient(transparent, rgba(8, 9, 13, 0.92));
+  font-family: var(--font-family-heading);
+  gap: 0.1rem;
+  padding: 1.5rem 0.4rem 0.4rem;
+}
+
+.fff-plus-demo-player > media-play-button[slot="centered-chrome"] {
+  --media-button-icon-height: 2.15rem;
+  --media-button-icon-width: 2.15rem;
+  --media-control-background: rgba(8, 9, 13, 0.76);
+  --media-control-hover-background: #fb923c;
+  backdrop-filter: blur(0.65rem);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  box-shadow: 0 0.7rem 2rem rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}
+
+.fff-plus-demo-player[mediahasplayed]
+  > media-play-button[slot="centered-chrome"] {
+  display: none;
+}
+
+@media (max-width: 38rem) {
+  .fff-plus-demo-player media-seek-backward-button,
+  .fff-plus-demo-player media-seek-forward-button,
+  .fff-plus-demo-player media-playback-rate-button,
+  .fff-plus-demo-player media-pip-button {
+    display: none;
+  }
+
+  .fff-plus-demo-player media-time-display {
+    font-size: 0.75rem;
+  }
+}
+
 .toc {
   background: var(--gray-bg);
   border: 1px solid var(--gray-line);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3407,6 +3407,11 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
+ce-la-react@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ce-la-react/-/ce-la-react-0.3.2.tgz#66c1454e024c3b9f65ebac05724d0f50756ff057"
+  integrity sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==
+
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -7687,6 +7692,13 @@ meant@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/meant/-/meant-1.0.3.tgz#67769af9de1d158773e928ae82c456114903554c"
   integrity sha512-88ZRGcNxAq4EH38cQ4D85PM57pikCwS8Z99EWHODxN7KBY+UuPiqzRTtZzS8KTXO/ywSWbdjjJST2Hly/EQxLw==
+
+media-chrome@^4.19.2:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/media-chrome/-/media-chrome-4.19.2.tgz#2321fdb82481a8c4aad558191b73863aa0ba95d1"
+  integrity sha512-4ai1ITN8wBhwugQcRgqe3tN0z6OSKGOXqHLNrS04MgKFfsLqu6Dm8MPq02pI9Y9ZKoXtFjIl85jOryIW9es3BA==
+  dependencies:
+    ce-la-react "^0.3.2"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
## What changed

- publishes a new post covering the fff-plus.nvim PR #7 improvements
- embeds the usage demo in a responsive Media Chrome player
- links the original fff-plus.nvim article to the new update
- keeps article tables usable on narrow screens

## Why

The blog should document the latest fff-plus.nvim picker improvements and let readers play the demo without leaving the page.

## Validation

- `git diff --check`
- `yarn build`
- desktop browser: player registered, MP4 loaded, and playback advanced without errors
- 390 px browser: responsive controls, no horizontal overflow, and playback advanced without errors

Note: Gatsby continues to print the pre-existing `json2xml-memory-infographic.svg` copy warning while completing the build successfully.